### PR TITLE
tests: Add a local alloy to publish host metrics

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -73,3 +73,92 @@
           description: A token to allow Akadmin to access services via APIs
           expiring: false
       register: _test
+
+    ##
+    # Example on how to connect a node-exporter to mimir deployed this way
+    ##
+    - name: Install alloy on the host and configure it
+      block:
+        - name: Install grafana apt gpg signing key
+          become: true
+          ansible.builtin.get_url:
+            url: https://apt.grafana.com/gpg.key
+            dest: /etc/apt/keyrings/grafana.asc
+            mode: "0o400"
+          register: _gpg_key
+
+        - name: Dearmor the grafana gpg key
+          become: true
+          ansible.builtin.command:
+            cmd: gpg --dearmor --output /etc/apt/keyrings/grafana.gpg /etc/apt/keyrings/grafana.asc
+          when: _gpg_key.changed
+          changed_when: true
+          tags:
+            - skip_ansible_lint
+
+        - name: Add grafana apt repository
+          become: true
+          ansible.builtin.apt_repository:
+            repo: deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main
+            state: present
+            filename: grafana
+
+        - name: Install alloy
+          become: true
+          ansible.builtin.apt:
+            name: alloy
+
+        - name: Create the agent's service account to authenticate
+          benschubert.infrastructure.authentik_user:
+            authentik_token: "{{ auth_authentik_token }}"
+            authentik_url: https://{{ auth_authentik_hostname }}:{{ ingress_https_port }}
+            ca_path: "{{ ingress_custom_ca_cert | default(omit) }}"
+            validate_certs: "{{ ingress_validate_certs }}"
+            user:
+              name: host-metrics
+              username: host-metrics
+              path: service-accounts
+              type: service_account
+          register: _service_account
+
+        - name: Create the agent's service account's token
+          benschubert.infrastructure.authentik_token:
+            authentik_token: "{{ auth_authentik_token }}"
+            authentik_url: https://{{ auth_authentik_hostname }}:{{ ingress_https_port }}
+            ca_path: "{{ ingress_custom_ca_cert | default(omit) }}"
+            validate_certs: "{{ ingress_validate_certs }}"
+            token:
+              identifier: host-metrics-agent-auth-token
+              intent: app_password
+              user: "{{ _service_account.data.pk }}"
+              description: Token to authenticate the agent against mimir
+              expiring: false
+
+        - name: Retrieve the generated token
+          benschubert.infrastructure.authentik_token_value:
+            authentik_token: "{{ auth_authentik_token }}"
+            authentik_url: https://{{ auth_authentik_hostname }}:{{ ingress_https_port }}
+            ca_path: "{{ ingress_custom_ca_cert | default(omit) }}"
+            validate_certs: "{{ ingress_validate_certs }}"
+            token: host-metrics-agent-auth-token
+          register: _mimir_service_account_token
+
+        - name: Configure alloy
+          become: true
+          ansible.builtin.template:
+            src: config.alloy.j2
+            dest: /etc/alloy/config.alloy
+            mode: "0o600"
+            owner: alloy
+            group: alloy
+          vars:
+            password: "{{ _mimir_service_account_token.key }}"
+            username: host-metrics
+          register: _alloy_config
+
+        - name: Ensure alloy is running
+          become: true
+          ansible.builtin.systemd:
+            service: alloy
+            state: "{{ 'restarted' if _alloy_config.changed else 'started' }}"
+            enabled: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,6 +10,7 @@ verifier:
 platforms:
   - name: ${CONTAINER_NAME:-benschubert-infrastructure-test-container}
     image: docker.io/debian:bookworm-slim
+    hostname: ${CONTAINER_NAME:-benschubert-infrastructure-test-container}
     command: /usr/sbin/init
     dockerfile: Dockerfile.j2
     etc_hosts:

--- a/molecule/default/templates/config.alloy.j2
+++ b/molecule/default/templates/config.alloy.j2
@@ -1,0 +1,30 @@
+logging {
+  level = "info"
+  format = "logfmt"
+}
+
+prometheus.exporter.unix "host" {}
+
+prometheus.scrape "host" {
+  scrape_interval = "30s"
+  targets = concat(
+    [{"__address__" = "localhost:12345", "instance" = "agent"}],
+    prometheus.exporter.unix.host.targets,
+  )
+  forward_to = [prometheus.remote_write.monitor.receiver]
+}
+
+prometheus.remote_write "monitor" {
+    endpoint {
+        url = "https://{{ monitoring_mimir_hostname }}:{{ ingress_https_port }}/api/v1/push"
+        basic_auth {
+          username = "{{ username }}"
+          password = "{{ password }}"
+        }
+        {% if (not ingress_validate_certs) or ingress_custom_ca_cert_url is not none %}
+        tls_config {
+          insecure_skip_verify = true
+        }
+        {% endif %}
+    }
+}

--- a/molecule/default/tests/test_monitoring.py
+++ b/molecule/default/tests/test_monitoring.py
@@ -1,3 +1,4 @@
+import os
 from http import HTTPStatus
 from typing import Any
 from urllib.parse import urlparse
@@ -71,14 +72,18 @@ def test_services_are_up(
             "prometheus.scrape.benschubert_infrastructure_monitoring_monitor",
             "1",
         ),
-        (
-            "auth-redis",
-            "integrations/redis",
-            "1",
-        ),
+        ("agent", "prometheus.scrape.host", "1"),
+        ("auth-redis", "integrations/redis", "1"),
         (
             "authentik",
             "prometheus.scrape.benschubert_infrastructure_auth_monitor",
+            "1",
+        ),
+        (
+            os.getenv(
+                "CONTAINER_NAME", "benschubert-infrastructure-test-container"
+            ),
+            "integrations/unix",
             "1",
         ),
         (


### PR DESCRIPTION
This ensures that systems outside of podman can properly access everything too, and provides an example