### PR TITLE
Add a deployment of Loki to handle monitoring logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ runs in rootless podman containers on the same machine.
 - [Authentik](https://goauthentik.io/) to handle SSO
 - [Grafana](https://grafana.com/) for viewing metrics and logs
 - [Mimir](https://grafana.com/oss/mimir/) to ingest logs and metrics, and provide an [AlertManager](https://prometheus.io/docs/alerting/latest/alertmanager/) deployment
+- [Loki](https://grafana.com/oss/loki/) to store logs and handle alerts based on logs
 - [Grafana Alloy](https://grafana.com/oss/alloy-opentelemetry-collector/) to publish metrics and logs

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -35,6 +35,9 @@ description: |
   * L(Mimir, https://grafana.com/oss/mimir/),
     using R(the monitoring role, ansible_collections.benschubert.infrastructure.monitoring_role),
     which allows ingesting and storing metrics and alerts.
+  * L(Loki, https://grafana.com/oss/loki/),
+    using R(the monitoring role, ansible_collections.benschubert.infrastructure.monitoring_role),
+    which allows ingesting and storing logs, and connects to Mimir for alerts.
   * L(Grafana Alloy, https://grafana.com/oss/alloy-opentelemetry-collector/),
     using R(the monitoring role, ansible_collections.benschubert.infrastructure.monitoring_role),
     which allows collecting metrics and logs

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -163,3 +163,23 @@
             service: alloy
             state: "{{ 'restarted' if _alloy_config.changed else 'started' }}"
             enabled: true
+
+        - name: Ensure the directory to store alerts exists
+          become_method: containers.podman.podman_unshare
+          become: true
+          ansible.builtin.file:
+            name: "{{ monitoring_loki_config_path }}/rules/fake"
+            state: directory
+            owner: 19218
+            group: 19218
+            mode: "0o755"
+
+        - name: Install alloy alerts
+          become: true
+          become_method: containers.podman.podman_unshare
+          ansible.builtin.template:
+            src: alerts.yml.j2
+            dest: "{{ monitoring_loki_config_path }}/rules/fake/node.yml"
+            owner: 19218
+            group: 19218
+            mode: "0o644"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -17,6 +17,7 @@ platforms:
       ${AUTHENTIK_HOSTNAME:-auth.test}: 127.0.0.1
       ${TRAEFIK_HOSTNAME:-traefik.test}: 127.0.0.1
       ${GRAFANA_HOSTNAME:-grafana.test}: 127.0.0.1
+      ${LOKI_HOSTNAME:-loki.test}: 127.0.0.1
       ${MIMIR_HOSTNAME:-mimir.test}: 127.0.0.1
     security_opts:
       - label=disable
@@ -59,6 +60,7 @@ provisioner:
         auth_authentik_hostname: ${AUTHENTIK_HOSTNAME:-auth.test}
         ingress_traefik_dashboard_hostname: ${TRAEFIK_HOSTNAME:-traefik.test}
         monitoring_grafana_hostname: ${GRAFANA_HOSTNAME:-grafana.test}
+        monitoring_loki_hostname: ${LOKI_HOSTNAME:-loki.test}
         monitoring_mimir_hostname: ${MIMIR_HOSTNAME:-mimir.test}
 
         ##
@@ -103,6 +105,8 @@ provisioner:
         monitoring_grafana_postgres_password: postgresgrafanapassword
         monitoring_grafana_postgres_data_path: "{{ data }}/monitoring/grafana/postgres"
         monitoring_grafana_data_path: "{{ data }}/monitoring/grafana/grafana"
+        monitoring_loki_config_path: "{{ data }}/monitoring/loki/config"
+        monitoring_loki_data_path: "{{ data }}/monitoring/loki/data"
         monitoring_mimir_config_path: "{{ data }}/monitoring/mimir/config"
         monitoring_mimir_data_path: "{{ data }}/monitoring/mimir/data"
         monitoring_monitor_agent_config_path: "{{ data }}/monitoring/agent/config"

--- a/molecule/default/templates/alerts.yml.j2
+++ b/molecule/default/templates/alerts.yml.j2
@@ -1,0 +1,24 @@
+{{ template_warning }}
+---
+groups:
+  - name: Logs
+    rules:
+      - alert: HighContainerLogRate
+        expr: sum by (container) (rate({container=~".+"}[1m])) > 10
+        for: 1m
+        labels:
+          severity: warning
+          category: logs
+        annotations:
+          title: High LogRate Alert for container {{ '{{' }}$labels.container{{ '}}' }}
+          description: The container {{ '{{' }}$labels.container{{ '}}' }} is generating a lot of logs
+
+      - alert: ErrorInContainerLogs
+        expr: sum by(container) (rate({container=~".+"} |= `` | detected_level = `error` [1m])) > 0.1
+        for: 1m
+        labels:
+          severity: critical
+          category: logs
+        annotations:
+          title: High amount of errors in logs for container {{ '{{' }}$labels.container{{ '}}' }}"
+          description: "{{ '{{' }}$value{{ '}}' }} Errors occurred in logs for container {{ '{{' }}$labels.container{{ '}}' }}"

--- a/molecule/default/templates/config.alloy.j2
+++ b/molecule/default/templates/config.alloy.j2
@@ -28,3 +28,37 @@ prometheus.remote_write "monitor" {
         {% endif %}
     }
 }
+
+loki.relabel "journal" {
+  forward_to = []
+
+  rule {
+    source_labels = ["__journal__systemd_unit"]
+    target_label  = "unit"
+  }
+  rule {
+    source_labels = ["__journal_container_name"]
+    target_label  = "container"
+  }
+}
+
+loki.source.journal "read"  {
+  forward_to    = [loki.write.endpoint.receiver]
+  relabel_rules = loki.relabel.journal.rules
+  labels        = {component = "loki.source.journal"}
+}
+
+loki.write "endpoint" {
+  endpoint {
+    url ="https://{{ monitoring_loki_hostname }}:{{ ingress_https_port }}/loki/api/v1/push"
+    basic_auth {
+      username = "{{ username }}"
+      password = "{{ password }}"
+    }
+    {% if (not ingress_validate_certs) or ingress_custom_ca_cert_url is not none %}
+    tls_config {
+        insecure_skip_verify = true
+    }
+    {% endif %}
+  }
+}

--- a/molecule/default/tests/test_monitoring.py
+++ b/molecule/default/tests/test_monitoring.py
@@ -92,6 +92,11 @@ def test_services_are_up(
             "1",
         ),
         (
+            "loki",
+            "prometheus.scrape.benschubert_infrastructure_monitoring_monitor",
+            "1",
+        ),
+        (
             "mimir",
             "prometheus.scrape.benschubert_infrastructure_monitoring_monitor",
             "1",

--- a/roles/auth/tasks/main.yml
+++ b/roles/auth/tasks/main.yml
@@ -106,7 +106,7 @@
     image: ghcr.io/goauthentik/server
     command: server
     env:
-      AUTHENTIK_LOG_LEVEL: trace
+      AUTHENTIK_LOG_LEVEL: info
       AUTHENTIK_SECRET_KEY: file:///run/secrets/auth-authentik-secret-key
       AUTHENTIK_POSTGRESQL__HOST: auth-postgres
       AUTHENTIK_POSTGRESQL__USER: authentik

--- a/roles/main/defaults/main.yml
+++ b/roles/main/defaults/main.yml
@@ -5,6 +5,7 @@ ingress_networks:
 
 ingress_network_aliases:
   - "{{ auth_authentik_hostname }}"
+  - "{{ monitoring_loki_hostname }}"
   - "{{ monitoring_mimir_hostname }}"
 
 ingress_additional_networks: []

--- a/roles/main/meta/argument_specs.yml
+++ b/roles/main/meta/argument_specs.yml
@@ -295,11 +295,26 @@ argument_specs:
         required: true
         description:
           - The secret key to use in Grafana to encrypt various sensitive data
+      monitoring_loki_config_path:
+        type: str
+        required: true
+        description:
+          - The path on disk where the Loki configuration files should be stored.
+      monitoring_loki_data_path:
+        type: str
+        required: true
+        description:
+          - The path on disk where the Loki data should be stored.
+      monitoring_loki_hostname:
+        type: str
+        required: true
+        description:
+          - The hostname at which the Loki instance is reachable.
       monitoring_mimir_hostname:
         type: str
         required: true
         description:
-          - The hostname at which the Mimir instance is reachable
+          - The hostname at which the Mimir instance is reachable.
       monitoring_mimir_config_path:
         type: str
         required: true

--- a/roles/monitoring/meta/argument_specs.yml
+++ b/roles/monitoring/meta/argument_specs.yml
@@ -10,6 +10,7 @@ argument_specs:
       - L(Grafana, https://grafana.com/)
       - L(Mimir, https://grafana.com/oss/mimir/), including L(AlertManager,
         https://grafana.com/docs/mimir/latest/references/architecture/components/alertmanager/)
+      - L(Loki, https://grafana.com/oss/loki/)
       - L(Grafana Alloy, https://grafana.com/oss/alloy-opentelemetry-collector/)
     options:
       auth_authentik_hostname:
@@ -99,11 +100,26 @@ argument_specs:
         required: true
         description:
           - The secret key to use in Grafana to encrypt various sensitive data
+      monitoring_loki_config_path:
+        type: str
+        required: true
+        description:
+          - The path on disk where the Loki configuration files should be stored.
+      monitoring_loki_data_path:
+        type: str
+        required: true
+        description:
+          - The path on disk where the Loki data should be stored.
+      monitoring_loki_hostname:
+        type: str
+        required: true
+        description:
+          - The hostname at which the Loki instance is reachable.
       monitoring_mimir_hostname:
         type: str
         required: true
         description:
-          - The hostname at which the Mimir instance is reachable
+          - The hostname at which the Mimir instance is reachable.
       monitoring_mimir_config_path:
         type: str
         required: true

--- a/roles/monitoring/tasks/_loki.yml
+++ b/roles/monitoring/tasks/_loki.yml
@@ -1,0 +1,92 @@
+---
+- name: Ensure the Loki paths exist
+  become_method: containers.podman.podman_unshare
+  become: true
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: 19218
+    group: 19218
+    mode: "0o700"
+  loop:
+    - "{{ monitoring_loki_config_path }}/rules"
+    - "{{ monitoring_loki_data_path }}"
+
+- name: Create the Loki configuration file
+  become_method: containers.podman.podman_unshare
+  become: true
+  ansible.builtin.template:
+    src: loki.yml.j2
+    dest: "{{ monitoring_loki_config_path }}/local-config.yaml"
+    mode: "0o444"
+    owner: 19218
+    group: 19218
+  register: _configuration
+
+- name: Create the Loki network
+  containers.podman.podman_network:
+    name: ingress-monitoring
+    internal: true
+
+- name: Create the Loki pod
+  containers.podman.podman_pod:
+    name: monitoring-loki
+    state: created
+    infra_name: monitoring-loki-infra
+    network:
+      - ingress-monitoring
+    userns: auto:size=10002
+
+- name: Setup the Loki container
+  containers.podman.podman_container:
+    name: monitoring-loki-loki
+    pod: monitoring-loki
+    state: started
+    image: docker.io/grafana/loki
+    healthcheck: wget -O- http://localhost:3100/ready
+    force_restart: "{{ _configuration.changed }}"
+    read_only: true
+    volumes:
+      - "{{ monitoring_loki_config_path }}:/etc/loki/:ro,U,Z"
+      - "{{ monitoring_loki_config_path }}/rules:/etc/loki/rules:U,Z"
+      - "{{ monitoring_loki_data_path }}:/data/loki:U,Z"
+
+- name: Ensure the Loki container is healthy
+  ansible.builtin.command: podman healthcheck run monitoring-loki-loki
+  register: _healthcheck
+  until: _healthcheck is not failed
+  retries: 3
+  changed_when: false
+
+- name: Create an application for Loki on Authentik
+  ansible.builtin.import_role:
+    name: auth
+    tasks_from: application
+  vars:
+    application_name: loki
+    application_slug: benschubert-infrastructure-loki
+    group: admin
+    meta_description: Loki
+    icon_url: https://grafana.com/media/docs/loki/logo-grafana-loki.png
+    provider_proxy:
+      hostname: "{{ monitoring_loki_hostname }}"
+
+- name: Setup an ingress for Loki
+  ansible.builtin.import_role:
+    name: benschubert.infrastructure.ingress
+    tasks_from: provider
+  vars:
+    template_file: ingress-loki.yml.j2
+    ingress_name: loki
+    hostname: "{{ monitoring_loki_hostname }}"
+    expected_status_code: 302
+
+- name: Register Loki as a datasource on Grafana
+  community.grafana.grafana_datasource:
+    name: loki
+    ds_type: loki
+    ds_url: http://monitoring-loki:3100
+    grafana_url: https://{{ monitoring_grafana_hostname }}:{{ ingress_https_port }}
+    grafana_user: "{{ monitoring_grafana_admin_user }}"
+    grafana_password: "{{ monitoring_grafana_admin_password }}"
+    validate_certs: false

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -7,6 +7,10 @@
   ansible.builtin.import_tasks:
     file: _mimir.yml
 
+- name: Setup Loki
+  ansible.builtin.import_tasks:
+    file: _loki.yml
+
 - name: Monitor the monitoring services
   ansible.builtin.import_role:
     name: monitoring
@@ -25,6 +29,9 @@
         alerting_rules_template: mimir-alerts.yml.j2
       - name: grafana
         address: monitoring-grafana:3000
+      - name: loki
+        address: monitoring-loki:3100
+        alerting_rules_template: loki-alerts.yml.j2
     monitoring_agent_postgres_instances:
       - instance: monitoring-grafana-postgres
         username: grafana

--- a/roles/monitoring/templates/ingress-loki.yml.j2
+++ b/roles/monitoring/templates/ingress-loki.yml.j2
@@ -1,0 +1,40 @@
+{{ template_warning }}
+---
+http:
+  routers:
+    loki:
+      rule: Host(`{{ hostname }}`)
+      service: loki
+      priority: 10
+      tls: { {% if ingress_traefik_certificates_resolvers %}"certResolver": "default"{% endif %} }
+      middlewares:
+        - loki-auth@file
+
+    loki-auth:
+      rule: Host(`{{ hostname }}`) && PathPrefix(`/outpost.goauthentik.io/`)
+      priority: 15
+      service: authentik@file
+
+  services:
+    loki:
+      loadBalancer:
+        servers:
+          - url: http://monitoring-loki:3100
+
+  middlewares:
+    loki-auth:
+      forwardAuth:
+        address: http://auth:9000/outpost.goauthentik.io/auth/traefik
+        trustForwardHeader: true
+        authResponseHeaders:
+          - X-authentik-username
+          - X-authentik-groups
+          - X-authentik-email
+          - X-authentik-name
+          - X-authentik-uid
+          - X-authentik-jwt
+          - X-authentik-meta-jwks
+          - X-authentik-meta-outpost
+          - X-authentik-meta-provider
+          - X-authentik-meta-app
+          - X-authentik-meta-version

--- a/roles/monitoring/templates/loki-alerts.yml.j2
+++ b/roles/monitoring/templates/loki-alerts.yml.j2
@@ -1,0 +1,11 @@
+{% set log_instance = "(instance {{ $labels.instance }})" %}
+{% set log_values_and_labels = "VALUE = {{ $value }}\\n  LABELS = {{ $labels }}" -%}
+
+- alert: LokiRequestErrors
+  expr: rate(loki_request_duration_seconds_count{instance="{{ name }}", status_code=~"5.."}[1m]) > 0
+  for: 0m
+  labels:
+    severity: critical
+  annotations:
+    summary: Loki encountered request errors {{ log_instance }}
+    description: Loki is encountering errors responding on the API\n  {{ log_values_and_labels }}

--- a/roles/monitoring/templates/loki.yml.j2
+++ b/roles/monitoring/templates/loki.yml.j2
@@ -1,0 +1,54 @@
+{{ template_warning }}
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /data/loki
+  storage:
+    filesystem:
+      chunks_directory: /data/loki/chunks
+      rules_directory: /data/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+ruler:
+  alertmanager_url: http://monitoring-mimir:9009/alertmanager
+  storage:
+    type: local
+    local:
+      directory: /etc/loki/rules
+  rule_path: /data/loki/rules
+  enable_alertmanager_v2: true
+  external_url: https://{{ monitoring_grafana_hostname }}:{{ ingress_https_port }}
+  enable_api: true
+  remote_write:
+    enabled: true
+    client:
+      url: http://monitoring-mimir:9009/api/v1/push
+  wal:
+    dir: /data/loki/ruler/wal
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+analytics:
+  reporting_enabled: false

--- a/roles/monitoring/templates/mimir.yml.j2
+++ b/roles/monitoring/templates/mimir.yml.j2
@@ -1,6 +1,9 @@
 {{ template_warning }}
 multitenancy_enabled: false
 
+usage_stats:
+  enabled: false
+
 target: all,alertmanager
 
 activity_tracker:


### PR DESCRIPTION
This adds a deployment of loki and hooks it up with MImir's AlertManager and Grafana for viewing logs.

It also adds an example of how to ship logs from podman using journald and add examples alerts for it