### PR TITLE
Allow overriding any of the images used by the roles

### DIFF
--- a/roles/auth/defaults/main.yml
+++ b/roles/auth/defaults/main.yml
@@ -4,6 +4,7 @@ ingress_https_port: 443
 
 auth_authentik_authentication_page_title: Welcome, please login
 auth_authentik_branding_title: Authentik
+auth_authentik_image: ghcr.io/goauthentik/server:latest
 auth_authentik_superadmin_bootstrap_email: null
 auth_authentik_superadmin_bootstrap_password: null
 auth_authentik_superadmin_bootstrap_token: null

--- a/roles/auth/meta/argument_specs.yml
+++ b/roles/auth/meta/argument_specs.yml
@@ -80,6 +80,10 @@ argument_specs:
         type: str
         description:
           - Name of the SVG file to use as an icon for Authentik on login screen
+      auth_authentik_image:
+        type: str
+        default: ghcr.io/goauthentik/server:latest
+        description: The container image path and tag to use for Authentik
       auth_authentik_secret_key:
         type: str
         required: true
@@ -108,11 +112,19 @@ argument_specs:
         required: true
         description:
           - The path on disk where to store the monitoring's agent data
+      auth_monitor_agent_alloy_image:
+        type: str
+        default: See I(monitoring_agent_alloy_image) from the Monitoring role
+        description: The container image path and tag to use for Alloy
       auth_postgres_data_path:
         type: str
         required: true
         description:
           - The path on disk where the PostgreSQL instance should store its data
+      auth_postgres_image:
+        type: str
+        default: See I(postgres_image) from the Postgres role
+        description: The container image path and tag to use for Postgres
       auth_postgres_password:
         type: str
         required: true
@@ -129,6 +141,10 @@ argument_specs:
         required: true
         description:
           - The path on disk where the Redis instance should store its data
+      auth_redis_image:
+        type: str
+        default: See I(redis_image) from the Redis role
+        description: The container image path and tag to use for Redis
       auth_redis_metrics_password:
         type: str
         required: true

--- a/roles/auth/tasks/main.yml
+++ b/roles/auth/tasks/main.yml
@@ -64,6 +64,11 @@
     - name: auth-authentik-email-password
       data: "{{ auth_authentik_email_config.password | default(None) }}"
 
+- name: Configure the postgres image if not provided explicitly
+  ansible.builtin.set_fact:
+    auth_postgres_image: "{{ postgres_image }}"
+  when: auth_postgres_image is not defined
+
 - name: Create the Authentik database
   ansible.builtin.import_role:
     name: benschubert.infrastructure.postgres
@@ -71,9 +76,15 @@
     postgres_pod: auth-postgres
     postgres_password_secret: auth-postgres-password
     postgres_data_path: "{{ auth_postgres_data_path }}"
+    postgres_image: "{{ auth_postgres_image }}"
     postgres_user: authentik
     postgres_database: authentik
     postgres_network: auth-postgres
+
+- name: Configure the Redis image if not provided explicitly
+  ansible.builtin.set_fact:
+    auth_redis_image: "{{ redis_image }}"
+  when: auth_redis_image is not defined
 
 - name: Create the Authentik redis instance
   ansible.builtin.import_role:
@@ -82,6 +93,7 @@
     redis_pod: auth-redis
     redis_config_path: "{{ auth_redis_config_path }}"
     redis_data_path: "{{ auth_redis_data_path }}"
+    redis_image: "{{ auth_redis_image }}"
     redis_network: auth-redis
     redis_password: "{{ auth_redis_password }}"
     redis_metrics_password: "{{ auth_redis_metrics_password }}"
@@ -112,7 +124,7 @@
     name: auth-authentik
     pod: auth
     state: started
-    image: ghcr.io/goauthentik/server
+    image: "{{ auth_authentik_image }}"
     command: server
     env:
       AUTHENTIK_LOG_LEVEL: info
@@ -196,7 +208,7 @@
     name: auth-worker-authentik
     pod: auth-worker
     state: started
-    image: ghcr.io/goauthentik/server
+    image: "{{ auth_authentik_image }}"
     command: worker
     env:
       AUTHENTIK_SECRET_KEY: file:///run/secrets/auth-authentik-secret-key
@@ -267,6 +279,11 @@
     hostname: "{{ auth_authentik_hostname }}"
     expected_status_code: 302
 
+- name: Configure the Alloy image if not provided explicitly
+  ansible.builtin.set_fact:
+    auth_monitor_agent_alloy_image: "{{ monitoring_agent_alloy_image }}"
+  when: auth_monitor_agent_alloy_image is not defined
+
 - name: Monitor Authentik
   ansible.builtin.import_role:
     name: monitoring
@@ -275,6 +292,7 @@
     monitoring_agent_product_name: auth
     monitoring_agent_config_path: "{{ auth_monitor_agent_config_path }}"
     monitoring_agent_data_path: "{{ auth_monitor_agent_data_path }}"
+    monitoring_agent_alloy_image: "{{ auth_monitor_agent_alloy_image }}"
     monitoring_agent_networks:
       - ingress-auth
       - auth-postgres

--- a/roles/ingress/defaults/main.yml
+++ b/roles/ingress/defaults/main.yml
@@ -4,4 +4,5 @@ ingress_https_port: 443
 
 ingress_traefik_certificates_resolvers: {}
 ingress_traefik_environment_variables: {}
+ingress_traefik_image: docker.io/traefik:latest
 ingress_traefik_secrets: {}

--- a/roles/ingress/meta/argument_specs.yml
+++ b/roles/ingress/meta/argument_specs.yml
@@ -161,6 +161,10 @@ argument_specs:
         required: true
         description:
           - The path on disk where to store the monitoring's agent data
+      ingress_monitor_agent_alloy_image:
+        type: str
+        default: See I(monitoring_agent_alloy_image) from the Monitoring role
+        description: The container image path and tag to use for Alloy
       ingress_traefik_dashboard_hostname:
         type: str
         required: true
@@ -184,6 +188,10 @@ argument_specs:
           - "'storage' MUST be set as C(/etc/traefik/acme.json)"
           - See L(Traefik's documentation,
             https://doc.traefik.io/traefik/https/acme/) for more information
+      ingress_traefik_image:
+        type: str
+        default: docker.io/traefik:latest
+        description: The container image path and tag to use for Traefik
       ingress_validate_certs:
         type: bool
         default: true

--- a/roles/ingress/tasks/finalize.yml
+++ b/roles/ingress/tasks/finalize.yml
@@ -23,6 +23,11 @@
     hostname: "{{ ingress_traefik_dashboard_hostname }}"
     expected_status_code: 302
 
+- name: Configure the Alloy image if not provided explicitly
+  ansible.builtin.set_fact:
+    ingress_monitor_agent_alloy_image: "{{ monitoring_agent_alloy_image }}"
+  when: ingress_monitor_agent_alloy_image is not defined
+
 - name: Monitor Traefik
   ansible.builtin.import_role:
     name: monitoring
@@ -31,6 +36,7 @@
     monitoring_agent_product_name: ingress
     monitoring_agent_config_path: "{{ ingress_monitor_agent_config_path }}"
     monitoring_agent_data_path: "{{ ingress_monitor_agent_data_path }}"
+    monitoring_agent_alloy_image: "{{ ingress_monitor_agent_alloy_image }}"
     monitoring_agent_networks:
       - ingress
     monitoring_agent_pod: ingress-monitor

--- a/roles/ingress/tasks/main.yml
+++ b/roles/ingress/tasks/main.yml
@@ -68,7 +68,7 @@
   containers.podman.podman_container:
     name: ingress-traefik
     pod: ingress
-    image: docker.io/traefik:latest
+    image: "{{ ingress_traefik_image }}"
     state: started
     force_restart: "{{ _configuration.changed }}"
     volumes:

--- a/roles/main/meta/argument_specs.yml
+++ b/roles/main/meta/argument_specs.yml
@@ -79,6 +79,10 @@ argument_specs:
         type: str
         description:
           - Name of the SVG file to use as an icon for Authentik on login screen
+      auth_authentik_image:
+        type: str
+        default: See I(auth_authentik_image) in the auth role
+        description: The container image path and tag to use for Authentik
       auth_authentik_secret_key:
         type: str
         required: true
@@ -117,12 +121,20 @@ argument_specs:
         required: true
         description:
           - The path on disk where to store the monitoring's agent data
+      auth_monitor_agent_alloy_image:
+        type: str
+        default: See I(monitoring_agent_alloy_image) from the Monitoring role
+        description: The container image path and tag to use for Alloy
       auth_postgres_data_path:
         type: str
         required: true
         description:
           - The path on disk where the PostgreSQL instance for Authentik should
             store its data
+      auth_postgres_image:
+        type: str
+        default: See I(postgres_image) from the Postgres role
+        description: The container image path and tag to use for Postgres
       auth_postgres_password:
         type: str
         required: true
@@ -140,6 +152,10 @@ argument_specs:
         description:
           - The path on disk where the Authentik Redis instance should store its
             data
+      auth_redis_image:
+        type: str
+        default: See I(redis_image) from the Redis role
+        description: The container image path and tag to use for Redis
       auth_redis_metrics_password:
         type: str
         required: true
@@ -193,6 +209,10 @@ argument_specs:
         description:
           - The path on disk where to store the monitoring's agent data for the
             ingress services
+      ingress_monitor_agent_alloy_image:
+        type: str
+        default: See I(monitoring_agent_alloy_image) from the Monitoring role
+        description: The container image path and tag to use for Alloy
       ingress_networks:
         type: list
         elements: str
@@ -240,6 +260,10 @@ argument_specs:
           - The path on disk to a custom certificate to validate the TLS
             certificates if they are not available in the root certificate
             authorities
+      ingress_traefik_image:
+        type: str
+        default: See I(ingress_traefik_image) in the ingress role
+        description: The container image path and tag to use for Traefik
       ingress_traefik_dashboard_hostname:
         type: str
         required: true
@@ -283,12 +307,21 @@ argument_specs:
         required: true
         description:
           - The directory in which the Grafana data will be stored
+      monitoring_grafana_image:
+        type: str
+        default: See I(monitoring_grafana_image) from the monitoring role
+        description:
+          - The container image path and tag to use for Grafana
       monitoring_grafana_postgres_data_path:
         type: str
         required: true
         description:
           - The path on disk where the PostgreSQL instance for Grafana should
             store its data
+      monitoring_grafana_postgres_image:
+        type: str
+        default: See I(postgres_image) from the Postgres role
+        description: The container image path and tag to use for Postgres
       monitoring_grafana_postgres_password:
         type: str
         required: true
@@ -319,6 +352,11 @@ argument_specs:
         required: true
         description:
           - The hostname at which the Loki instance is reachable.
+      monitoring_loki_image:
+        type: str
+        default: See I(monitoring_loki_image) from the monitoring role
+        description:
+          - The container image path and tag to use for Loki
       monitoring_mimir_hostname:
         type: str
         required: true
@@ -334,6 +372,11 @@ argument_specs:
         required: true
         description:
           - The path on disk where the Mimir data should be stored.
+      monitoring_mimir_image:
+        type: str
+        default: See I(monitoring_mimir_image) from the monitoring role
+        description:
+          - The container image path and tag to use for Mimir
       monitoring_monitor_agent_config_path:
         type: str
         required: true
@@ -346,6 +389,10 @@ argument_specs:
         description:
           - The path at which the Grafana Alloy monitoring the monitoring stack
             should store its data
+      monitoring_monitor_agent_alloy_image:
+        type: str
+        default: See I(monitoring_agent_alloy_image) from the Monitoring role
+        description: The container image path and tag to use for Alloy
 
       ##
       # Miscellaneous

--- a/roles/monitoring/defaults/main.yml
+++ b/roles/monitoring/defaults/main.yml
@@ -4,3 +4,7 @@ monitoring_grafana_admin_user: admin
 monitoring_grafana_admin_password: "{{ monitoring_grafana_admin_bootstrap_password }}"
 monitoring_agent_prometheus_endpoints: {}
 monitoring_agent_postgres_instances: []
+monitoring_agent_alloy_image: docker.io/grafana/alloy:latest
+monitoring_grafana_image: docker.io/grafana/grafana:latest
+monitoring_loki_image: docker.io/grafana/loki:latest
+monitoring_mimir_image: docker.io/grafana/mimir:latest

--- a/roles/monitoring/meta/argument_specs.yml
+++ b/roles/monitoring/meta/argument_specs.yml
@@ -79,12 +79,21 @@ argument_specs:
         required: true
         description:
           - The directory in which the Grafana data will be stored
+      monitoring_grafana_image:
+        type: str
+        default: docker.io/grafana/grafana:latest
+        description:
+          - The container image path and tag to use for Grafana
       monitoring_grafana_postgres_data_path:
         type: str
         required: true
         description:
           - The path on disk where the PostgreSQL instance for Grafana should
             store its data
+      monitoring_grafana_postgres_image:
+        type: str
+        default: See I(postgres_image) from the Postgres role
+        description: The container image path and tag to use for Postgres
       monitoring_grafana_postgres_password:
         type: str
         required: true
@@ -115,6 +124,11 @@ argument_specs:
         required: true
         description:
           - The hostname at which the Loki instance is reachable.
+      monitoring_loki_image:
+        type: str
+        default: docker.io/grafana/loki:latest
+        description:
+          - The container image path and tag to use for Loki
       monitoring_mimir_hostname:
         type: str
         required: true
@@ -130,6 +144,11 @@ argument_specs:
         required: true
         description:
           - The path on disk where the Mimir data should be stored.
+      monitoring_mimir_image:
+        type: str
+        default: docker.io/grafana/mimir:latest
+        description:
+          - The container image path and tag to use for Mimir
       monitoring_monitor_agent_config_path:
         type: str
         required: true
@@ -142,6 +161,10 @@ argument_specs:
         description:
           - The path at which the Grafana Alloy monitoring the monitoring stack
             should store its data
+      monitoring_monitor_agent_alloy_image:
+        type: str
+        default: See I(monitoring_agent_alloy_image) from the Monitoring role
+        description: The container image path and tag to use for Alloy
   agent:
     short_description: >-
       Configure a Grafana alloy service to monitor some systems
@@ -188,6 +211,11 @@ argument_specs:
         required: true
         description:
           - The path on disk where the agent can store it's own data
+      monitoring_agent_alloy_image:
+        type: str
+        default: docker.io/grafana/alloy:latest
+        description:
+          - The container image path and tag to use for Alloy
       monitoring_agent_networks:
         type: list
         elements: str

--- a/roles/monitoring/tasks/_grafana.yml
+++ b/roles/monitoring/tasks/_grafana.yml
@@ -78,6 +78,11 @@
     - name: monitoring-grafana-secret-key
       data: "{{ monitoring_grafana_secret_key }}"
 
+- name: Configure the postgres image if not provided explicitly
+  ansible.builtin.set_fact:
+    monitoring_grafana_postgres_image: "{{ postgres_image }}"
+  when: monitoring_grafana_postgres_image is not defined
+
 - name: Create the Grafana database
   ansible.builtin.import_role:
     name: benschubert.infrastructure.postgres
@@ -85,6 +90,7 @@
     postgres_pod: monitoring-grafana-postgres
     postgres_password_secret: monitoring-grafana-postgres-password
     postgres_data_path: "{{ monitoring_grafana_postgres_data_path }}"
+    postgres_image: "{{ monitoring_grafana_postgres_image }}"
     postgres_user: grafana
     postgres_database: grafana
     postgres_network: monitoring-grafana-postgres
@@ -104,7 +110,7 @@
     name: monitoring-grafana-grafana
     pod: monitoring-grafana
     state: started
-    image: docker.io/grafana/grafana
+    image: "{{ monitoring_grafana_image }}"
     healthcheck: curl --fail http://localhost:3000
     read_only: true
     env:

--- a/roles/monitoring/tasks/_loki.yml
+++ b/roles/monitoring/tasks/_loki.yml
@@ -42,7 +42,7 @@
     name: monitoring-loki-loki
     pod: monitoring-loki
     state: started
-    image: docker.io/grafana/loki
+    image: "{{ monitoring_loki_image }}"
     healthcheck: wget -O- http://localhost:3100/ready
     force_restart: "{{ _configuration.changed }}"
     read_only: true

--- a/roles/monitoring/tasks/_mimir.yml
+++ b/roles/monitoring/tasks/_mimir.yml
@@ -48,7 +48,7 @@
     pod: monitoring-mimir
     state: started
     force_restart: "{{ _configuration.changed }}"
-    image: docker.io/grafana/mimir
+    image: "{{ monitoring_mimir_image }}"
     command: --config.file=/etc/mimir/mimir.yml
     # FIXME: the image from 2.13 now doesn't have curl or wget
     # healthcheck: wget -O- http://localhost:9009

--- a/roles/monitoring/tasks/agent.yml
+++ b/roles/monitoring/tasks/agent.yml
@@ -95,7 +95,7 @@
     name: "{{ monitoring_agent_pod }}-agent"
     pod: "{{ monitoring_agent_pod }}"
     state: started
-    image: docker.io/grafana/alloy
+    image: "{{ monitoring_agent_alloy_image }}"
     command:
       - run
       - --disable-reporting

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -11,6 +11,11 @@
   ansible.builtin.import_tasks:
     file: _loki.yml
 
+- name: Configure the Alloy image if not provided explicitly
+  ansible.builtin.set_fact:
+    monitoring_monitor_agent_alloy_image: "{{ monitoring_agent_alloy_image }}"
+  when: monitoring_monitor_agent_alloy_image is not defined
+
 - name: Monitor the monitoring services
   ansible.builtin.import_role:
     name: monitoring
@@ -19,6 +24,7 @@
     monitoring_agent_product_name: monitoring
     monitoring_agent_config_path: "{{ monitoring_monitor_agent_config_path }}"
     monitoring_agent_data_path: "{{ monitoring_monitor_agent_data_path }}"
+    monitoring_agent_alloy_image: "{{ monitoring_monitor_agent_alloy_image }}"
     monitoring_agent_networks:
       - ingress-monitoring
       - monitoring-grafana-postgres

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+postgres_image: docker.io/library/postgres:latest

--- a/roles/postgres/meta/argument_specs.yml
+++ b/roles/postgres/meta/argument_specs.yml
@@ -13,6 +13,10 @@ argument_specs:
         type: str
         required: true
         description: The name of the database to create
+      postgres_image:
+        type: str
+        default: docker.io/library/postgres:latest
+        description: The container image path and tag to use for Postgres
       postgres_network:
         type: str
         required: true

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -25,7 +25,7 @@
   containers.podman.podman_container:
     name: "{{ postgres_pod }}-postgres"
     pod: "{{ postgres_pod }}"
-    image: docker.io/library/postgres:latest
+    image: "{{ postgres_image }}"
     user: postgres
     state: started
     volumes:

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+redis_image: docker.io/library/redis:latest

--- a/roles/redis/meta/argument_specs.yml
+++ b/roles/redis/meta/argument_specs.yml
@@ -19,6 +19,10 @@ argument_specs:
         required: true
         description: >-
           The path on disk where Redis will store it's data for persistence
+      redis_image:
+        type: str
+        default: docker.io/library/redis:latest
+        description: The container image path and tag to use for Redis
       redis_metrics_password:
         type: str
         required: true

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -40,7 +40,7 @@
   containers.podman.podman_container:
     name: "{{ redis_pod }}-redis"
     pod: "{{ redis_pod }}"
-    image: docker.io/library/redis:latest
+    image: "{{ redis_image }}"
     command: [redis-server, /etc/redis.conf]
     user: redis
     state: started


### PR DESCRIPTION
This allows users to pin versions of the dependencies and thus avoid having unschedules or untested updates happening