### PR TITLE
Always pull an image if there is a newer one

### DIFF
--- a/roles/auth/tasks/main.yml
+++ b/roles/auth/tasks/main.yml
@@ -156,6 +156,7 @@
       AUTHENTIK_EMAIL__USE_SSL: "{{ auth_authentik_email_config.ssl | default(omit) }}"
       AUTHENTIK_EMAIL__FROM: "{{ auth_authentik_email_config.from | default(omit) }}"
     healthcheck: /lifecycle/ak healthcheck
+    pull: newer
     volumes: >-
       {{
         [
@@ -242,6 +243,7 @@
       AUTHENTIK_EMAIL__USE_SSL: "{{ auth_authentik_email_config.ssl | default(omit) }}"
       AUTHENTIK_EMAIL__FROM: "{{ auth_authentik_email_config.from | default(omit) }}"
     healthcheck: /lifecycle/ak healthcheck
+    pull: newer
     volumes:
       # yamllint disable-line rule:line-length
       - "{{ auth_authentik_configuration_path }}/blueprints:/blueprints/benschubert-infrastructure:ro,Z"

--- a/roles/ingress/tasks/main.yml
+++ b/roles/ingress/tasks/main.yml
@@ -71,6 +71,7 @@
     image: "{{ ingress_traefik_image }}"
     state: started
     force_restart: "{{ _configuration.changed }}"
+    pull: newer
     volumes:
       - "{{ ingress_traefik_configuration_files_path }}/config:/etc/traefik:ro,U,Z"
       - "{{ ingress_traefik_configuration_files_path }}/acme.json:/etc/traefik/acme.json:rw,U,Z"

--- a/roles/monitoring/tasks/_grafana.yml
+++ b/roles/monitoring/tasks/_grafana.yml
@@ -149,6 +149,7 @@
       GF_SECURITY_SECRET_KEY__FILE: /run/secrets/monitoring-grafana-secret-key
       GF_SECURITY_ADMIN_USER: "{{ monitoring_grafana_admin_user }}"
       GF_SECURITY_ADMIN_PASSWORD: "{{ monitoring_grafana_admin_bootstrap_password }}"
+    pull: newer
     secrets:
       - monitoring-grafana-postgres-password,target=/run/secrets/monitoring-grafana-postgres-password
       - monitoring-grafana-client-secret,target=/run/secrets/monitoring-grafana-client-secret

--- a/roles/monitoring/tasks/_loki.yml
+++ b/roles/monitoring/tasks/_loki.yml
@@ -46,6 +46,7 @@
     healthcheck: wget -O- http://localhost:3100/ready
     force_restart: "{{ _configuration.changed }}"
     read_only: true
+    pull: newer
     volumes:
       - "{{ monitoring_loki_config_path }}:/etc/loki/:ro,U,Z"
       - "{{ monitoring_loki_config_path }}/rules:/etc/loki/rules:U,Z"

--- a/roles/monitoring/tasks/_mimir.yml
+++ b/roles/monitoring/tasks/_mimir.yml
@@ -52,6 +52,7 @@
     command: --config.file=/etc/mimir/mimir.yml
     # FIXME: the image from 2.13 now doesn't have curl or wget
     # healthcheck: wget -O- http://localhost:9009
+    pull: newer
     read_only: true
     volumes:
       - "{{ monitoring_mimir_config_path }}:/etc/mimir/:ro,U,Z"

--- a/roles/monitoring/tasks/agent.yml
+++ b/roles/monitoring/tasks/agent.yml
@@ -106,6 +106,7 @@
     #        we should be able to set it to curl/wget
     # healthcheck: wget -O- http://localhost:9009/-/healthy
     healthcheck: /bin/true
+    pull: newer
     read_only: true
     secrets: >-
       {{

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -37,6 +37,7 @@
     secrets:
       - "{{ postgres_password_secret }},target=/run/secrets/postgres-password"
     healthcheck: pg_isready -d $${POSTGRES_DB -U $${POSTGRES_USER}
+    pull: newer
     read_only: true
 
 - name: Ensure the PostgreSQL container is healthy

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -49,6 +49,7 @@
       - "{{ redis_config_path }}/redis.conf:/etc/redis.conf:ro,U,Z"
       - "{{ redis_data_path }}/:/data:rw,U,Z"
     healthcheck: redis-cli --user ping --pass '' ping | grep PONG
+    pull: newer
     read_only: true
 
 - name: Ensure the Redis container is healthy


### PR DESCRIPTION
Now that users can pin to a specific version of each service, we should always ensure we're on the latest version for the tag