### PR TITLE
Skip specifying ports when using the default ones

### DIFF
--- a/roles/auth/tasks/application.yml
+++ b/roles/auth/tasks/application.yml
@@ -69,7 +69,9 @@
     provider:
       name: "{{ application_name }}"
       authorization_flow: "{{ _authorization_flow.data.pk }}"
-      external_host: https://{{ provider_proxy.hostname }}:{{ ingress_https_port }}
+      external_host: https://{{ provider_proxy.hostname }}{{
+          "" if ingress_https_port == 443 else ":{}".format(ingress_https_port)
+        }}
       invalidation_flow: "{{ _invalidation_flow.data.pk }}"
       mode: forward_single
   register: _provider_proxy_result

--- a/roles/ingress/tasks/provider.yml
+++ b/roles/ingress/tasks/provider.yml
@@ -19,7 +19,9 @@
 
 - name: Wait until the service is accessible
   ansible.builtin.uri:
-    url: https://{{ hostname }}:{{ ingress_https_port }}/
+    url: https://{{ hostname }}{{
+        "" if ingress_https_port == 443 else ":{}".format(ingress_https_port)
+      }}/
     ca_path: "{{ ingress_custom_ca_cert | default(omit) }}"
     validate_certs: "{{ ingress_validate_certs }}"
     follow_redirects: none


### PR DESCRIPTION
Otherwise Authentik gets confused when trying to access :443, as the ports are not specified.