### PR TITLE
 Allow restricting access to apps to specific groups 

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -84,15 +84,6 @@
       ansible.builtin.import_role:
         name: benschubert.infrastructure.mailpit_test_gateway
 
-    - name: Get the Grafana group info
-      benschubert.infrastructure.authentik_group_info:
-        authentik_token: "{{ auth_authentik_token }}"
-        authentik_url: https://{{ auth_authentik_hostname }}:{{ ingress_https_port }}
-        ca_path: "{{ ingress_custom_ca_cert | default(omit) }}"
-        validate_certs: "{{ ingress_validate_certs }}"
-        name: "{{ monitoring_grafana_admin_group_name }}"
-      register: group
-
     - name: Get the akadmin user info
       benschubert.infrastructure.authentik_user_info:
         authentik_token: "{{ auth_authentik_token }}"
@@ -102,14 +93,26 @@
         username: akadmin
       register: user
 
-    - name: Add akadmin to the grafana admin group
-      benschubert.infrastructure.authentik_user_group:
-        authentik_token: "{{ auth_authentik_token }}"
-        authentik_url: https://{{ auth_authentik_hostname }}:{{ ingress_https_port }}
-        ca_path: "{{ ingress_custom_ca_cert | default(omit) }}"
-        validate_certs: "{{ ingress_validate_certs }}"
-        user_pk: "{{ user.data.pk }}"
-        group_pk: "{{ group.data.pk }}"
+    - name: Add akadmin to the admin group
+      when: test_akadmin_user_group
+      block:
+        - name: Get the Grafana group info
+          benschubert.infrastructure.authentik_group_info:
+            authentik_token: "{{ auth_authentik_token }}"
+            authentik_url: https://{{ auth_authentik_hostname }}:{{ ingress_https_port }}
+            ca_path: "{{ ingress_custom_ca_cert | default(omit) }}"
+            validate_certs: "{{ ingress_validate_certs }}"
+            name: "{{ test_akadmin_user_group }}"
+          register: _group
+
+        - name: Add akadmin to the admin group
+          benschubert.infrastructure.authentik_user_group:
+            authentik_token: "{{ auth_authentik_token }}"
+            authentik_url: https://{{ auth_authentik_hostname }}:{{ ingress_https_port }}
+            ca_path: "{{ ingress_custom_ca_cert | default(omit) }}"
+            validate_certs: "{{ ingress_validate_certs }}"
+            user_pk: "{{ user.data.pk }}"
+            group_pk: "{{ _group.data.pk }}"
 
     - name: Create a token to access services as akadmin
       benschubert.infrastructure.authentik_token:
@@ -122,6 +125,31 @@
           intent: app_password
           user: "{{ user.data.pk }}"
           description: A token to allow Akadmin to access services via APIs
+          expiring: false
+
+    - name: Create a non-privileged user
+      benschubert.infrastructure.authentik_user:
+        authentik_token: "{{ auth_authentik_token }}"
+        authentik_url: https://{{ auth_authentik_hostname }}:{{ ingress_https_port }}
+        ca_path: "{{ ingress_custom_ca_cert | default(omit) }}"
+        validate_certs: "{{ ingress_validate_certs }}"
+        user:
+          name: molecule-unprivileged-test-user
+          username: molecule-unprivileged-test-user
+          type: internal
+      register: _molecule_unprivileged_user
+
+    - name: Create a token to access Authentik as molecule-unprivileged-test-user
+      benschubert.infrastructure.authentik_token:
+        authentik_token: "{{ auth_authentik_token }}"
+        authentik_url: https://{{ auth_authentik_hostname }}:{{ ingress_https_port }}
+        ca_path: "{{ ingress_custom_ca_cert | default(omit) }}"
+        validate_certs: "{{ ingress_validate_certs }}"
+        token:
+          identifier: molecule-unprivileged-test-user-password
+          intent: api
+          user: "{{ _molecule_unprivileged_user.data.pk }}"
+          description: A token to allow the unprivileged user to talk to Authentik
           expiring: false
 
     ##
@@ -170,6 +198,28 @@
               path: service-accounts
               type: service_account
           register: _service_account
+
+        - name: Add the service account to the requested group
+          when: default_monitor_agent_user_group
+          block:
+            - name: Ensure the requested group exists
+              benschubert.infrastructure.authentik_group:
+                authentik_token: "{{ auth_authentik_token }}"
+                authentik_url: https://{{ auth_authentik_hostname }}:{{ ingress_https_port }}
+                ca_path: "{{ ingress_custom_ca_cert | default(omit) }}"
+                validate_certs: "{{ ingress_validate_certs }}"
+                group:
+                  name: "{{ default_monitor_agent_user_group }}"
+              register: _service_account_group
+
+            - name: Add the service account to the group
+              benschubert.infrastructure.authentik_user_group:
+                authentik_token: "{{ auth_authentik_token }}"
+                authentik_url: https://{{ auth_authentik_hostname }}:{{ ingress_https_port }}
+                ca_path: "{{ ingress_custom_ca_cert | default(omit) }}"
+                validate_certs: "{{ ingress_validate_certs }}"
+                group_pk: "{{ _service_account_group.data.pk }}"
+                user_pk: "{{ _service_account.data.pk }}"
 
         - name: Create the agent's service account's token
           benschubert.infrastructure.authentik_token:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -87,6 +87,17 @@ provisioner:
           - auth-worker-mailpit
           - monitoring-mimir-mailpit
 
+        # Group membership
+        default_monitor_agent_user_group: ${MONITOR_AGENT_USER_GROUP:-null}
+        test_akadmin_user_group: ${TEST_AKADMIN_USER_GROUP:-null}
+        monitoring_grafana_admin_group_name: ${GRAFANA_ADMIN_GROUP_NAME:-Grafana Admins}
+
+        ingress_traefik_allowlisted_groups: ${TRAEFIK_ALLOWLISTED_GROUPS:-null}
+        monitoring_grafana_allowlisted_groups: ${GRAFANA_ALLOWLISTED_GROUPS:-null}
+        monitoring_loki_allowlisted_groups: ${LOKI_ALLOWLISTED_GROUPS:-null}
+        monitoring_mimir_allowlisted_groups: ${MIMIR_ALLOWLISTED_GROUPS:-null}
+        mailpit_test_gateway_allowlisted_groups: ${MAILPIT_ALLOWLISTED_GROUPS:-null}
+
         ##
         # Ingress
         ##

--- a/molecule/default/privileged-env.yml
+++ b/molecule/default/privileged-env.yml
@@ -1,3 +1,18 @@
 # This file can be copied to a .env.yml at the root of the repo to reproduce
+
+##
+# Ports
 HTTP_PORT: "80"
 HTTPS_PORT: "443"
+
+##
+# Group membership
+TEST_AKADMIN_USER_GROUP: admins
+MONITOR_AGENT_USER_GROUP: metrics-bots
+GRAFANA_ADMIN_GROUP_NAME: admins
+
+GRAFANA_ALLOWLISTED_GROUPS: "[admins]"
+LOKI_ALLOWLISTED_GROUPS: "[admins]"
+MAILPIT_ALLOWLISTED_GROUPS: "[admins]"
+MIMIR_ALLOWLISTED_GROUPS: "[admins, metrics-bots]"
+TRAEFIK_ALLOWLISTED_GROUPS: "[admins]"

--- a/plugins/modules/authentik_policy_binding.py
+++ b/plugins/modules/authentik_policy_binding.py
@@ -1,0 +1,168 @@
+DOCUMENTATION = """
+module: authentik_policy_binding
+
+short_description: Allow administration of policy bindings in Authentik
+
+description:
+  - This module allows the administration of Policy bindings  via the Authentik
+    API
+  - See https://docs.goauthentik.io/docs/customize/policies/working_with_policies/
+
+options:
+  binding:
+    description:
+      - The configuration for the binding
+      - At least one of C(group), C(policy) or C(user) needs to be provided
+    type: dict
+    required: true
+    suboptions:
+      enabled:
+        description:
+          - Whether the policy is enabled or not
+        type: bool
+        default: true
+      failure_result:
+        description:
+          - The result if the policy execution fails
+        type: bool
+        default: false
+      group:
+        description:
+          - The pk of the group to allow/deny access to the given flow or application
+        type: str
+        default: null
+      negate:
+        description:
+          - Negates the outcome of the policy
+        type: bool
+        default: false
+      order:
+        description:
+          - The place in the list of policies bindings where this needs to be
+            evaluated
+        type: int
+        required: true
+      policy:
+        description:
+          - The policy to bind against the target
+        type: str
+        default: null
+      target:
+        description:
+          - The pk of the flow or application against which the policy must be
+            bound
+        type: str
+        required: true
+      user:
+        description:
+          - The pk of the user to allow/deny access to the given flow or application
+        type: str
+        default: null
+
+extends_documentation_fragment:
+  - benschubert.infrastructure.authentik
+  - benschubert.infrastructure.authentik.stateful
+
+author:
+  - Benjamin Schubert (@benjaminschubert)
+"""
+
+EXAMPLES = """
+- name: Restrict access to app {{ app }} to group {{ group }}
+  benschubert.infrastructure.policy_binding:
+    authentik_token: <my-secret-token>
+    authentik_url: https://authentik.test
+    binding:
+      group: "{{ group.pk }}"
+      order: 0
+      target: "{{ app.pk }}"
+
+- name: Forbid access to app {{ app }} from user {{ user }}
+  benschubert.infrastructure.policy_binding:
+    authentik_token: <my-secret-token>
+    authentik_url: https://authentik.test
+    binding:
+      negate: true
+      order: 0
+      user: "{{ user.pk }}"
+      target: "{{ app.pk }}"
+
+- name: Bind the policy {{ policy }} to the flow {{ flow }}
+  benschubert.infrastructure.policy_binding:
+    authentik_token: <my-secret-token>
+    authentik_url: https://authentik.test
+    binding:
+      order: 0
+      policy: "{{ policy.pk }}"
+      target: "{{ flow.pk }}"
+"""
+
+
+from typing import Any, NoReturn, cast
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.benschubert.infrastructure.plugins.module_utils.authentik import (
+    Authentik,
+    execute,
+    get_base_arguments,
+)
+
+
+def main() -> NoReturn:  # type: ignore[misc]
+    argument_spec = get_base_arguments()
+    argument_spec["binding"] = {
+        "type": "dict",
+        "required": True,
+        "options": {
+            "enabled": {"type": "bool", "default": True},
+            "failure_result": {"type": "bool", "default": False},
+            "group": {"type": "str"},
+            "negate": {"type": "bool", "default": False},
+            "order": {"type": "int", "required": True},
+            "policy": {"type": "str"},
+            "target": {"type": "str", "required": True},
+            "user": {"type": "str"},
+        },
+        "required_one_of": [("group", "policy", "user")],
+    }
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    binding = module.params["binding"]
+
+    # The Authentik API doesn't allow search by group or user
+    def find(authentik: Authentik) -> dict[str, Any] | None:
+        if binding["policy"] is not None:
+            return cast(
+                dict[str, Any] | None,
+                authentik.get_one(
+                    {"target": binding["target"], "policy": binding["policy"]}
+                ),
+            )
+
+        resp = authentik.request(queryparams={"target": binding["target"]})
+        assert resp is not None
+
+        for result in resp["results"]:
+            for key in ["group", "user"]:
+                if binding[key] is not None and binding[key] == result[key]:
+                    return cast(dict[str, Any] | None, result)
+
+        return None
+
+    execute(
+        module,
+        "/api/v3/policies/bindings/",
+        pk_name="pk",
+        search_query=None,
+        desired_value=binding,
+        state=module.params["state"],
+        find=find,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/authentik_token.py
+++ b/plugins/modules/authentik_token.py
@@ -25,8 +25,9 @@ options:
         description:
           - "The intended usage for the token:"
           - "C(app_password): for authenticating against other applications"
+          - "C(api): for authenticating with the Authentik API"
         type: str
-        choices: [app_password]
+        choices: [app_password, api]
         required: true
       user:
         description:
@@ -96,7 +97,7 @@ def main() -> NoReturn:  # type: ignore[misc]
             "identifier": {"type": "str", "required": True},
             "intent": {
                 "type": "str",
-                "choices": ["app_password"],
+                "choices": ["app_password", "api"],
                 "required": True,
             },
             "user": {"type": "int", "required": True},

--- a/plugins/modules/authentik_user.py
+++ b/plugins/modules/authentik_user.py
@@ -12,7 +12,7 @@ description:
 options:
   user:
     description:
-      - The configuration for the specified group
+      - The configuration for the specified user
     type: dict
     required: true
     suboptions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ disable = [
     "redefined-outer-name",
     "too-few-public-methods",
     "too-many-arguments",
+    "too-many-branches",
     "too-many-positional-arguments",
     "unused-argument",
     "wrong-import-position",
@@ -65,6 +66,7 @@ line-length = 79
 select = ["ALL"]
 ignore = [
     "ANN401",  # Allow using Any as typing
+    "C901",  # Disable complexity checks
     "COM812",  # Otherwise conflicts with the formatter
     "D104",  # Don't force documenting packages
     "D107",  # Don't document __init__
@@ -80,7 +82,8 @@ ignore = [
 ]
 
 pycodestyle.max-line-length = 119
-pylint.max-args = 7
+pylint.max-args = 8
+pylint.max-branches = 13
 
 [tool.ruff.lint.per-file-ignores]
 "docs/*" = [

--- a/roles/auth/defaults/main.yml
+++ b/roles/auth/defaults/main.yml
@@ -9,4 +9,5 @@ auth_authentik_superadmin_bootstrap_email: null
 auth_authentik_superadmin_bootstrap_password: null
 auth_authentik_superadmin_bootstrap_token: null
 auth_authentik_token: "{{ auth_authentik_superadmin_bootstrap_token }}"
+auth_monitor_agent_user_group: null
 auth_worker_additional_networks: []

--- a/roles/auth/meta/argument_specs.yml
+++ b/roles/auth/meta/argument_specs.yml
@@ -116,6 +116,14 @@ argument_specs:
         type: str
         default: See I(monitoring_agent_alloy_image) from the Monitoring role
         description: The container image path and tag to use for Alloy
+      auth_monitor_agent_user_group:
+        type: str
+        default: null
+        description:
+          - A group name to which to add the role account that is created for
+            monitoring Authentik.
+          - This is useful if you want to restrict apps per user, so you can
+            have those bots publish their metrics correctly.
       auth_postgres_data_path:
         type: str
         required: true
@@ -199,6 +207,15 @@ argument_specs:
         L(proxy provider, https://docs.goauthentik.io/docs/add-secure-apps/providers/proxy/) in
         order to protect an application via Authentik.
     options:
+      allowlisted_groups:
+        type: list
+        elements: str
+        default: null
+        description:
+          - A list of groups to restrict the application to.
+          - Users not in any of the specified groups won't be able to see or
+            login to the application.
+          - C(null) or C([]) doesn't restrict the access.
       application_name:
         type: str
         required: true

--- a/roles/auth/tasks/application.yml
+++ b/roles/auth/tasks/application.yml
@@ -97,6 +97,7 @@
       group: "{{ group }}"
       open_in_new_tab: true
       meta_description: "{{ meta_description }}"
+  register: _app
 
 - name: Configure the application icon for {{ application_name }}
   benschubert.infrastructure.authentik_application_icon_url:
@@ -127,3 +128,31 @@
     validate_certs: "{{ ingress_validate_certs }}"
     outpost_name: authentik Embedded Outpost
     provider_pk: "{{ _provider_result.data.pk }}"
+
+- name: Restrict access to the application to the selected groups for {{ application_name }}
+  when: allowlisted_groups
+  block:
+    - name: Ensure the requested group exists for {{ application_name }}
+      benschubert.infrastructure.authentik_group:
+        authentik_token: "{{ auth_authentik_token }}"
+        authentik_url: https://{{ auth_authentik_hostname }}:{{ ingress_https_port }}
+        ca_path: "{{ ingress_custom_ca_cert | default(omit) }}"
+        validate_certs: "{{ ingress_validate_certs }}"
+        group:
+          name: "{{ item }}"
+      loop: "{{ allowlisted_groups or [] }}"
+      register: _groups
+
+    - name: Restrict access to the provided group for {{ application_name }}
+      benschubert.infrastructure.authentik_policy_binding:
+        authentik_token: "{{ auth_authentik_token }}"
+        authentik_url: https://{{ auth_authentik_hostname }}:{{ ingress_https_port }}
+        ca_path: "{{ ingress_custom_ca_cert | default(omit) }}"
+        validate_certs: "{{ ingress_validate_certs }}"
+        binding:
+          group: "{{ item.data.pk }}"
+          order: 0
+          target: "{{ _app.data.pk }}"
+      loop: "{{ _groups.results }}"
+      loop_control:
+        label: "{{ item.data.name }}"

--- a/roles/auth/tasks/main.yml
+++ b/roles/auth/tasks/main.yml
@@ -320,3 +320,4 @@
       - name: auth-redis
         user: metrics
         password: "{{ auth_redis_metrics_password }}"
+    monitoring_agent_user_group: "{{ auth_monitor_agent_user_group }}"

--- a/roles/ingress/defaults/main.yml
+++ b/roles/ingress/defaults/main.yml
@@ -2,6 +2,9 @@
 ingress_http_port: 80
 ingress_https_port: 443
 
+ingress_monitor_agent_user_group: null
+
+ingress_traefik_allowlisted_groups: null
 ingress_traefik_certificates_resolvers: {}
 ingress_traefik_environment_variables: {}
 ingress_traefik_image: docker.io/traefik:latest

--- a/roles/ingress/meta/argument_specs.yml
+++ b/roles/ingress/meta/argument_specs.yml
@@ -166,6 +166,23 @@ argument_specs:
         type: str
         default: See I(monitoring_agent_alloy_image) from the Monitoring role
         description: The container image path and tag to use for Alloy
+      ingress_monitor_agent_user_group:
+        type: str
+        default: null
+        description:
+          - A group name to which to add the user that is created for monitoring
+            Traefik.
+          - This is useful if you want to restrict apps per user, so you can
+            have those bots publish their metrics correctly.
+      ingress_traefik_allowlisted_groups:
+        type: list
+        elements: str
+        default: null
+        description:
+          - A list of groups to restrict the Traefik dashboard to.
+          - Users not in any of the specified groups won't be able to see or
+            login to the dashboard.
+          - C(null) or C([]) doesn't restrict the access.
       ingress_traefik_dashboard_hostname:
         type: str
         required: true

--- a/roles/ingress/tasks/finalize.yml
+++ b/roles/ingress/tasks/finalize.yml
@@ -4,6 +4,7 @@
     name: benschubert.infrastructure.auth
     tasks_from: application
   vars:
+    allowlisted_groups: "{{ ingress_traefik_allowlisted_groups }}"
     application_name: Traefik's dashboard
     application_slug: benschubert-infrastructure-traefik-dashboard
     group: admin
@@ -46,6 +47,7 @@
         alerting_rules_template: traefik-alerts.yml.j2
     monitoring_agent_postgres_instances: []
     monitoring_agent_redis_instances: []
+    monitoring_agent_user_group: "{{ ingress_monitor_agent_user_group }}"
 
 - name: Install Traefik dashboards
   ansible.builtin.import_role:

--- a/roles/mailpit_test_gateway/defaults/main.yml
+++ b/roles/mailpit_test_gateway/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+mailpit_test_gateway_allowlisted_groups: null

--- a/roles/mailpit_test_gateway/meta/argument_specs.yml
+++ b/roles/mailpit_test_gateway/meta/argument_specs.yml
@@ -16,6 +16,15 @@ argument_specs:
         description:
           - The port at which the service is exposed via the ingress, in order
             to be able to make API calls to the service
+      mailpit_test_gateway_allowlisted_groups:
+        type: list
+        elements: str
+        default: null
+        description:
+          - A list of groups to restrict Mailpit to.
+          - Users not in any of the specified groups won't be able to see or
+            login to Mailpit.
+          - C(null) or C([]) doesn't restrict the access.
       mailpit_test_gateway_mailpit_hostname:
         type: str
         required: true

--- a/roles/mailpit_test_gateway/tasks/main.yml
+++ b/roles/mailpit_test_gateway/tasks/main.yml
@@ -42,6 +42,7 @@
     name: benschubert.infrastructure.auth
     tasks_from: application
   vars:
+    allowlisted_groups: "{{ mailpit_test_gateway_allowlisted_groups }}"
     application_name: MailPit
     application_slug: benschubert-infrastructure-mailpit
     group: admin

--- a/roles/main/defaults/main.yml
+++ b/roles/main/defaults/main.yml
@@ -9,3 +9,5 @@ ingress_network_aliases:
   - "{{ monitoring_mimir_hostname }}"
 
 ingress_additional_networks: []
+
+default_monitor_agent_user_group: null

--- a/roles/main/meta/argument_specs.yml
+++ b/roles/main/meta/argument_specs.yml
@@ -121,6 +121,15 @@ argument_specs:
         required: true
         description:
           - The path on disk where to store the monitoring's agent data
+      auth_monitor_agent_user_group:
+        type: str
+        default: null
+        description:
+          - A group name to which to add the role account that is created for
+            monitoring Authentik.
+          - This is useful if you want to restrict apps per user, so you can
+            have those bots publish their metrics correctly.
+          - Defaults to C(default_monitor_agent_user_group)
       auth_monitor_agent_alloy_image:
         type: str
         default: See I(monitoring_agent_alloy_image) from the Monitoring role
@@ -223,6 +232,14 @@ argument_specs:
         type: str
         default: See I(monitoring_agent_alloy_image) from the Monitoring role
         description: The container image path and tag to use for Alloy
+      ingress_monitor_agent_user_group:
+        type: str
+        default: null
+        description:
+          - A group name to which to add the role account that is created for
+            monitoring Traefik.
+          - This is useful if you want to restrict apps per user, so you can
+            have those bots publish their metrics correctly.
       ingress_networks:
         type: list
         elements: str
@@ -233,6 +250,15 @@ argument_specs:
           - The list of podman networks that the Traefik pod should attach to.
           - This is to let Traefik act as a reverse proxy for other services
             hosted in podman, without exposing them to other places.
+      ingress_traefik_allowlisted_groups:
+        type: list
+        elements: str
+        default: null
+        description:
+          - A list of groups to restrict the Traefik dashboard to.
+          - Users not in any of the specified groups won't be able to see or
+            login to the dashboard.
+          - C(null) or C([]) doesn't restrict the access.
       ingress_traefik_certificates_resolvers:
         type: dict
         default: {}
@@ -312,6 +338,17 @@ argument_specs:
         description:
           - The name of the admin user for Grafana. This user will not exist on
             the Authentik service
+      monitoring_grafana_allowlisted_groups:
+        type: list
+        elements: str
+        default: null
+        description:
+          - A list of groups to restrict Grafana to.
+          - Users not in any of the specified groups won't be able to see or
+            login to Grafana.
+          - C(null) or C([]) doesn't restrict the access.
+          - When setting this, you should at least add
+            C({{ monitoring_grafana_admin_group_name }}) to it.
       monitoring_grafana_config_path:
         type: str
         required: true
@@ -353,6 +390,15 @@ argument_specs:
         required: true
         description:
           - The secret key to use in Grafana to encrypt various sensitive data
+      monitoring_loki_allowlisted_groups:
+        type: list
+        elements: str
+        default: null
+        description:
+          - A list of groups to restrict Loki to.
+          - Users not in any of the specified groups won't be able to see or
+            login to Loki.
+          - C(null) or C([]) doesn't restrict the access.
       monitoring_loki_config_path:
         type: str
         required: true
@@ -387,6 +433,15 @@ argument_specs:
         default: mimir-alertmanager-fallback-config.yml.j2
         description:
           - The name of the template to use to configure the AlertManager routing
+      monitoring_mimir_allowlisted_groups:
+        type: list
+        elements: str
+        default: null
+        description:
+          - A list of groups to restrict Mimir to.
+          - Users not in any of the specified groups won't be able to see or
+            login to Mimir.
+          - C(null) or C([]) doesn't restrict the access.
       monitoring_mimir_hostname:
         type: str
         required: true
@@ -431,10 +486,29 @@ argument_specs:
         type: str
         default: See I(monitoring_agent_alloy_image) from the Monitoring role
         description: The container image path and tag to use for Alloy
+      monitoring_monitor_agent_user_group:
+        type: str
+        default: null
+        description:
+          - A group name to which to add the role account that is created for
+            monitoring the monitoring stack.
+          - This is useful if you want to restrict apps per user, so you can
+            have those bots publish their metrics correctly.
+          - Defaults to C(default_monitor_agent_user_group) if not set.
 
       ##
       # Miscellaneous
       ##
+      default_monitor_agent_user_group:
+        type: str
+        default: null
+        description:
+          - A group name to which to add the role account that is created for
+            monitoring services.
+          - This is useful if you want to restrict apps per user, so you can
+            have those bots publish their metrics correctly.
+          - This is the default value that each service-specific values will
+            take if they are not individually overridden
       template_warning:
         type: str
         required: true

--- a/roles/main/tasks/main.yml
+++ b/roles/main/tasks/main.yml
@@ -2,6 +2,12 @@
 - name: Expand configuration
   ansible.builtin.set_fact:
     ingress_networks: "{{ ingress_networks + ingress_additional_networks }}"
+    auth_monitor_agent_user_group: >-
+      {{ auth_monitor_agent_user_group or default_monitor_agent_user_group or omit }}
+    monitoring_monitor_agent_user_group: >-
+      {{ monitoring_monitor_agent_user_group or default_monitor_agent_user_group or omit }}
+    ingress_monitor_agent_user_group: >-
+      {{ ingress_monitor_agent_user_group or default_monitor_agent_user_group or omit }}
 
 - name: Validate configuration
   ansible.builtin.assert:

--- a/roles/monitoring/defaults/main.yml
+++ b/roles/monitoring/defaults/main.yml
@@ -2,12 +2,17 @@
 monitoring_grafana_admin_group_name: Grafana Admins
 monitoring_grafana_admin_user: admin
 monitoring_grafana_admin_password: "{{ monitoring_grafana_admin_bootstrap_password }}"
+monitoring_grafana_allowlisted_groups: null
+monitoring_agent_user_group: null
 monitoring_agent_prometheus_endpoints: {}
 monitoring_agent_postgres_instances: []
 monitoring_agent_alloy_image: docker.io/grafana/alloy:latest
 monitoring_grafana_image: docker.io/grafana/grafana:latest
+monitoring_loki_allowlisted_groups: null
 monitoring_loki_image: docker.io/grafana/loki:latest
 monitoring_mimir_image: docker.io/grafana/mimir:latest
 monitoring_mimir_additional_networks: []
 monitoring_mimir_alertmanager_config_template: mimir-alertmanager-fallback-config.yml.j2
+monitoring_mimir_allowlisted_groups: null
 monitoring_mimir_secrets: {}
+monitoring_monitor_agent_user_group: null

--- a/roles/monitoring/meta/argument_specs.yml
+++ b/roles/monitoring/meta/argument_specs.yml
@@ -74,6 +74,17 @@ argument_specs:
         description:
           - The name of the admin user for Grafana. This user will not exist on
             the Authentik service
+      monitoring_grafana_allowlisted_groups:
+        type: list
+        elements: str
+        default: null
+        description:
+          - A list of groups to restrict Grafana to.
+          - Users not in any of the specified groups won't be able to see or
+            login to Grafana.
+          - C(null) or C([]) doesn't restrict the access.
+          - When setting this, you should at least add
+            C({{ monitoring_grafana_admin_group_name }}) to it.
       monitoring_grafana_config_path:
         type: str
         required: true
@@ -114,6 +125,15 @@ argument_specs:
         required: true
         description:
           - The secret key to use in Grafana to encrypt various sensitive data
+      monitoring_loki_allowlisted_groups:
+        type: list
+        elements: str
+        default: null
+        description:
+          - A list of groups to restrict Loki to.
+          - Users not in any of the specified groups won't be able to see or
+            login to Loki.
+          - C(null) or C([]) doesn't restrict the access.
       monitoring_loki_config_path:
         type: str
         required: true
@@ -148,6 +168,15 @@ argument_specs:
         default: mimir-alertmanager-fallback-config.yml.j2
         description:
           - The name of the template to use to configure the AlertManager routing
+      monitoring_mimir_allowlisted_groups:
+        type: list
+        elements: str
+        default: null
+        description:
+          - A list of groups to restrict Mimir to.
+          - Users not in any of the specified groups won't be able to see or
+            login to Mimir.
+          - C(null) or C([]) doesn't restrict the access.
       monitoring_mimir_hostname:
         type: str
         required: true
@@ -192,6 +221,14 @@ argument_specs:
         type: str
         default: See I(monitoring_agent_alloy_image) from the Monitoring role
         description: The container image path and tag to use for Alloy
+      monitoring_monitor_agent_user_group:
+        type: str
+        default: null
+        description:
+          - A group name to which to add the role account that is created for
+            monitoring the monitoring stack.
+          - This is useful if you want to restrict apps per user, so you can
+            have those bots publish their metrics correctly.
   agent:
     short_description: >-
       Configure a Grafana alloy service to monitor some systems
@@ -342,6 +379,14 @@ argument_specs:
             required: true
             description:
               - The username to use to authenticate against Redis
+      monitoring_agent_user_group:
+        type: str
+        default: null
+        description:
+          - A group name to which to add the role account that is created for
+            monitoring the requested services.
+          - This is useful if you want to restrict apps per user, so you can
+            have those bots publish their metrics correctly.
   dashboard:
     short_description: Install the provided dashboard on Grafana
     description:

--- a/roles/monitoring/tasks/_grafana.yml
+++ b/roles/monitoring/tasks/_grafana.yml
@@ -39,6 +39,7 @@
     name: benschubert.infrastructure.auth
     tasks_from: application
   vars:
+    allowlisted_groups: "{{ monitoring_grafana_allowlisted_groups }}"
     application_name: grafana
     application_slug: benschubert-infrastructure-grafana
     group: admin

--- a/roles/monitoring/tasks/_loki.yml
+++ b/roles/monitoring/tasks/_loki.yml
@@ -64,6 +64,7 @@
     name: benschubert.infrastructure.auth
     tasks_from: application
   vars:
+    allowlisted_groups: "{{ monitoring_loki_allowlisted_groups }}"
     application_name: loki
     application_slug: benschubert-infrastructure-loki
     group: admin

--- a/roles/monitoring/tasks/_mimir.yml
+++ b/roles/monitoring/tasks/_mimir.yml
@@ -88,6 +88,7 @@
     name: benschubert.infrastructure.auth
     tasks_from: application
   vars:
+    allowlisted_groups: "{{ monitoring_mimir_allowlisted_groups }}"
     application_name: mimir
     application_slug: benschubert-infrastructure-mimir
     group: admin

--- a/roles/monitoring/tasks/agent.yml
+++ b/roles/monitoring/tasks/agent.yml
@@ -23,6 +23,28 @@
       type: service_account
   register: _service_account
 
+- name: Add the service account to the requested group for {{ monitoring_agent_product_name }}
+  when: monitoring_agent_user_group
+  block:
+    - name: Ensure the requested group exists for {{ monitoring_agent_product_name }}
+      benschubert.infrastructure.authentik_group:
+        authentik_token: "{{ auth_authentik_token }}"
+        authentik_url: https://{{ auth_authentik_hostname }}:{{ ingress_https_port }}
+        ca_path: "{{ ingress_custom_ca_cert | default(omit) }}"
+        validate_certs: "{{ ingress_validate_certs }}"
+        group:
+          name: "{{ monitoring_agent_user_group }}"
+      register: _service_account_group
+
+    - name: Add the service account to the group for {{ monitoring_agent_product_name }}
+      benschubert.infrastructure.authentik_user_group:
+        authentik_token: "{{ auth_authentik_token }}"
+        authentik_url: https://{{ auth_authentik_hostname }}:{{ ingress_https_port }}
+        ca_path: "{{ ingress_custom_ca_cert | default(omit) }}"
+        validate_certs: "{{ ingress_validate_certs }}"
+        group_pk: "{{ _service_account_group.data.pk }}"
+        user_pk: "{{ _service_account.data.pk }}"
+
 - name: Create the agent's service account's token for {{ monitoring_agent_product_name }}
   benschubert.infrastructure.authentik_token:
     authentik_token: "{{ auth_authentik_token }}"

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -44,3 +44,4 @@
         password: "{{ monitoring_grafana_postgres_password }}"
         database: grafana
     monitoring_agent_redis_instances: []
+    monitoring_agent_user_group: "{{ monitoring_monitor_agent_user_group }}"

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -3,6 +3,7 @@ plugins/modules/authentik_application_icon_url.py validate-modules:missing-gplv3
 plugins/modules/authentik_flow_info.py validate-modules:missing-gplv3-license
 plugins/modules/authentik_group.py validate-modules:missing-gplv3-license
 plugins/modules/authentik_group_info.py validate-modules:missing-gplv3-license
+plugins/modules/authentik_policy_binding.py validate-modules:missing-gplv3-license
 plugins/modules/authentik_propertymappings_scope_info.py validate-modules:missing-gplv3-license
 plugins/modules/authentik_provider_oauth2.py validate-modules:missing-gplv3-license
 plugins/modules/authentik_provider_info.py validate-modules:missing-gplv3-license


### PR DESCRIPTION
Not all services might be for everyone.

This adds the ability to restrict services per Authentik group, and exposes it on each application created