### PR TITLE
Enable using molecule >=6 by setting enough collections path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,8 @@ jobs:
         run: >-
           sudo sysctl net.ipv4.ip_unprivileged_port_start=80
           && cp molecule/default/privileged-env.yml .env.yml
+      - name: Ensure the default ansible collections directory is not written to by molecule
+        run: mkdir -p ~/.ansible/collections && chmod 0400 ~/.ansible/collections
       - name: molecule create
         run: molecule create
       - name: molecule converge

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyc
 
 # Testing
+.cache/
 .dwas/
 _artifacts/
 .env.yml

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+collections_path = ./.cache/collections

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -48,6 +48,7 @@ provisioner:
   env:
     ANSIBLE_PIPELINING: "True"
     ANSIBLE_DIFF_ALWAYS: "True"
+    ANSIBLE_COLLECTIONS_PATH: ${MOLECULE_PROJECT_DIRECTORY}/.cache/collections
   inventory:
     host_vars:
       ${CONTAINER_NAME:-benschubert-infrastructure-test-container}:

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,8 +1,5 @@
 -r requirements.txt
 -r requirements-tests.txt
 ansible-lint
-# FIXME: molecule 6 installs collections globally instead of locally, which
-#        defeats the isolation. (Check for files in ~/.ansible when updating
-#        See https://github.com/ansible/molecule/issues/4015
-molecule >=5,<6
+molecule
 molecule-plugins[podman]


### PR DESCRIPTION
The ansible.cfg is required because molecule does not look into the ephemeral directory it creates when doing create or destroy.

We then reuse that directory for the provisioner to avoid having to install roles twice