### PR TITLE
Fix the verify check that no alarms are triggering

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -90,7 +90,7 @@ provisioner:
 
         # Group membership
         default_monitor_agent_user_group: ${MONITOR_AGENT_USER_GROUP:-null}
-        test_akadmin_user_group: ${TEST_AKADMIN_USER_GROUP:-null}
+        test_akadmin_user_group: ${TEST_AKADMIN_USER_GROUP:-Grafana Admins}
         monitoring_grafana_admin_group_name: ${GRAFANA_ADMIN_GROUP_NAME:-Grafana Admins}
 
         ingress_traefik_allowlisted_groups: ${TRAEFIK_ALLOWLISTED_GROUPS:-null}

--- a/molecule/default/tests/test_monitoring.py
+++ b/molecule/default/tests/test_monitoring.py
@@ -201,7 +201,7 @@ def test_no_alerts_are_firing(
     entries = {
         (r["metric"]["state"], r["value"][1]) for r in result["data"]["result"]
     }
-    assert entries == {
+    assert entries <= {
         ("active", "0"),
         ("suppressed", "0"),
         ("unprocessed", "0"),
@@ -228,7 +228,7 @@ def test_all_alerts_are_valid(
         (r["metric"]["instance"], r["value"][1])
         for r in result["data"]["result"]
     }
-    assert entries == {("mimir", "0")}
+    assert entries <= {("mimir", "0")}
 
 
 def test_mimir_configuration_is_properly_loaded(


### PR DESCRIPTION
Mimir stopped exporting the metric when there's no alarms in Mimir 2.15

Also always add the default user to the list of users admins on grafana, which makes it easier to test locally