### PR TITLE
Ensure the OOB experience flow of Authentik ran before others

### DIFF
--- a/roles/auth/templates/tenant.yml.j2
+++ b/roles/auth/templates/tenant.yml.j2
@@ -6,6 +6,11 @@ entries:
 - model: authentik_blueprints.metaapplyblueprint
   attrs:
     identifiers:
+      name: Default - Out-of-box-experience flow
+    required: true
+- model: authentik_blueprints.metaapplyblueprint
+  attrs:
+    identifiers:
       name: benschubert.infrastructure - Authentication flow
     required: true
 - model: authentik_blueprints.metaapplyblueprint


### PR DESCRIPTION
It is a requirement for the Brand model, and tends to deadlock the system otherwise