### PR TITLE
Reduce the number of namespaces used to a minimum

### DIFF
--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -34,8 +34,8 @@ RUN apt-get update && \
 
 # Configure users
 RUN useradd --create-home --groups sudo --shell /bin/bash podman && \
-    echo "podman:10000:100000" > /etc/subuid && \
-    echo "podman:10000:100000" > /etc/subgid && \
+    echo "podman:10000:65534" > /etc/subuid && \
+    echo "podman:10000:65534" > /etc/subgid && \
     echo "%sudo ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers.d/sudo && \
     # And create cacheable volume for the storage
     mkdir -p /home/podman/.local/share/containers && \

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -270,8 +270,6 @@
           ansible.builtin.file:
             name: "{{ monitoring_loki_config_path }}/rules/fake"
             state: directory
-            owner: 19218
-            group: 19218
             mode: "0o755"
 
         - name: Install alloy Loki alerts
@@ -280,8 +278,6 @@
           ansible.builtin.template:
             src: loki-alerts.yml.j2
             dest: "{{ monitoring_loki_config_path }}/rules/fake/node.yml"
-            owner: 19218
-            group: 19218
             mode: "0o644"
 
         - name: Install the alerts for the host

--- a/roles/auth/tasks/main.yml
+++ b/roles/auth/tasks/main.yml
@@ -113,7 +113,7 @@
       - ingress-auth
       - auth-postgres
       - auth-redis
-    userns: auto:size=1024
+    userns: auto:size=1001
 
 - name: Create the auth-worker pod
   containers.podman.podman_pod:
@@ -123,7 +123,7 @@
     network: "{{
         ['auth-postgres', 'auth-redis'] + auth_worker_additional_networks
       }}"
-    userns: auto:size=1024
+    userns: auto:size=1001
 
 - name: Setup the Authentik server container
   containers.podman.podman_container:

--- a/roles/ingress/tasks/main.yml
+++ b/roles/ingress/tasks/main.yml
@@ -61,7 +61,7 @@
     publish:
       - "{{ ingress_http_port }}:{{ ingress_http_port }}"
       - "{{ ingress_https_port }}:{{ ingress_https_port }}"
-    userns: auto:size=1024
+    userns: auto:size=6
 
 - name: Setup the traefik container
   containers.podman.podman_container:

--- a/roles/mailpit_test_gateway/tasks/main.yml
+++ b/roles/mailpit_test_gateway/tasks/main.yml
@@ -12,7 +12,7 @@
     state: created
     infra_name: mailpit-infra
     network: "{{ mailpit_test_gateway_networks }}"
-    userns: auto:size=1024
+    userns: auto:size=6
 
 - name: Setup a Mailpit container
   containers.podman.podman_container:

--- a/roles/monitoring/tasks/_grafana.yml
+++ b/roles/monitoring/tasks/_grafana.yml
@@ -115,7 +115,7 @@
     network:
       - ingress-monitoring
       - monitoring-grafana-postgres
-    userns: auto:size=1024
+    userns: auto:size=473
 
 - name: Setup the Grafana container
   containers.podman.podman_container:

--- a/roles/monitoring/tasks/_loki.yml
+++ b/roles/monitoring/tasks/_loki.yml
@@ -5,8 +5,6 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    owner: 19218
-    group: 19218
     mode: "0o700"
   loop:
     - "{{ monitoring_loki_config_path }}/rules"
@@ -19,8 +17,6 @@
     src: loki.yml.j2
     dest: "{{ monitoring_loki_config_path }}/local-config.yaml"
     mode: "0o444"
-    owner: 19218
-    group: 19218
   register: _configuration
 
 - name: Create the Loki network

--- a/roles/monitoring/tasks/_mimir.yml
+++ b/roles/monitoring/tasks/_mimir.yml
@@ -6,8 +6,6 @@
     path: "{{ item }}"
     state: directory
     mode: "0o700"
-    owner: 8193
-    group: 8193
   loop:
     - "{{ monitoring_mimir_config_path }}/alertmanager"
     - "{{ monitoring_mimir_data_path }}/tmp"
@@ -19,8 +17,6 @@
     src: "{{ item.src }}"
     dest: "{{ monitoring_mimir_config_path }}/{{ item.dst }}"
     mode: "0o400"
-    owner: 8193
-    group: 8193
   register: _configuration
   loop:
     - src: mimir.yml.j2
@@ -47,7 +43,7 @@
     state: created
     infra_name: monitoring-mimir-infra
     network: "{{ ['ingress-monitoring'] + monitoring_mimir_additional_networks }}"
-    userns: auto:size=1024
+    userns: auto:size=6
 
 - name: Setup the Mimir container
   containers.podman.podman_container:

--- a/roles/monitoring/tasks/agent.yml
+++ b/roles/monitoring/tasks/agent.yml
@@ -117,7 +117,7 @@
     state: created
     infra_name: "{{ monitoring_agent_pod }}-infra"
     network: "{{ monitoring_agent_networks }}"
-    userns: auto:size=1024
+    userns: auto:size=474
 
 - name: Setup the Alloy's container for {{ monitoring_agent_product_name }}
   containers.podman.podman_container:

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -19,7 +19,7 @@
     infra_name: "{{ postgres_pod }}-infra"
     network:
       - "{{ postgres_network }}"
-    userns: auto:size=1024
+    userns: auto:size=1000
 
 - name: Setup a PostgreSQL container for {{ postgres_database }}
   containers.podman.podman_container:

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -34,7 +34,7 @@
     infra_name: "{{ redis_pod }}-infra"
     network:
       - "{{ redis_network }}"
-    userns: auto:size=1024
+    userns: auto:size=1000
 
 - name: Setup a Redis container for {{ redis_pod }}
   containers.podman.podman_container:


### PR DESCRIPTION
And stop specifying file modes explicitly, podman can update them at startup when required