### PR TITLE
Drop all capabilities whenever possible for every containers 

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -43,7 +43,9 @@
           ansible.builtin.set_fact:
             _containers_failing: "{{ _containers_failing | default([]) + [item] }}"
           loop: "{{ _containers.containers | sort(attribute='Name') }}"
-          when: item['State']['Health']['Status'] not in ['healthy', '']
+          when: >-
+            item["State"]["Status"] == "exited"
+            or item['State'].get('Health', {}).get('Status', '') not in ['healthy', '']
           loop_control:
             label: "{{ item['Name'] }}"
 
@@ -61,8 +63,8 @@
             msg: |
               Containers item:
               {% for item in _containers.containers | sort(attribute='Name') %}
-                {% set state = item["State"] %}
-                {{ item["Name"] }}: {{ state["Status"] }} {{ state["Health"]["Status"] or "-" }}
+                {% set s = item["State"] %}
+                {{ item["Name"] }}: {{ s["Status"] }} {{ s.get("Health", {}).get("Status", "-") }}
               {% endfor %}
 
               {% if _containers_failing | default(false) %}

--- a/roles/auth/tasks/main.yml
+++ b/roles/auth/tasks/main.yml
@@ -200,6 +200,7 @@
         )
       }}
     read_only: true
+    cap_drop: [all]
     force_restart: "{{ _background.changed or _icon.changed }}"
 
 - name: Ensure the Authentik container is healthy
@@ -268,6 +269,7 @@
         )
       }}
     read_only: true
+    cap_drop: [all]
 
 - name: Ensure the Authentik worker container is healthy
   ansible.builtin.command: podman healthcheck run auth-worker-authentik

--- a/roles/ingress/tasks/main.yml
+++ b/roles/ingress/tasks/main.yml
@@ -97,6 +97,10 @@
         | map('regex_replace', '_', '-')
         | map('regex_replace', '^(.*)$', 'ingress-traefik-\1')
       }}
+    cap_drop: [all]
+    cap_add:
+      # Required to bind on lower ports
+      - NET_BIND_SERVICE
 
 - name: Ensure the Traefik container is healthy
   ansible.builtin.command: podman healthcheck run ingress-traefik

--- a/roles/mailpit_test_gateway/tasks/main.yml
+++ b/roles/mailpit_test_gateway/tasks/main.yml
@@ -26,6 +26,7 @@
     healthcheck: /mailpit readyz
     pull: newer
     read_only: true
+    cap_drop: [all]
     secrets:
       - mailpit-smtp-auth
 

--- a/roles/monitoring/tasks/_grafana.yml
+++ b/roles/monitoring/tasks/_grafana.yml
@@ -125,6 +125,7 @@
     image: "{{ monitoring_grafana_image }}"
     healthcheck: curl --fail http://localhost:3000
     read_only: true
+    cap_drop: [all]
     env:
       # Login
       GF_AUTH_GENERIC_OAUTH_ENABLED: "true"

--- a/roles/monitoring/tasks/_loki.yml
+++ b/roles/monitoring/tasks/_loki.yml
@@ -42,6 +42,7 @@
     healthcheck: wget -O- http://localhost:3100/ready
     force_restart: "{{ _configuration.changed }}"
     read_only: true
+    cap_drop: [all]
     pull: newer
     volumes:
       - "{{ monitoring_loki_config_path }}:/etc/loki/:ro,U,Z"

--- a/roles/monitoring/tasks/_mimir.yml
+++ b/roles/monitoring/tasks/_mimir.yml
@@ -57,6 +57,7 @@
     # healthcheck: wget -O- http://localhost:9009
     pull: newer
     read_only: true
+    cap_drop: [all]
     secrets: |
       {{
         monitoring_mimir_secrets

--- a/roles/monitoring/tasks/agent.yml
+++ b/roles/monitoring/tasks/agent.yml
@@ -137,6 +137,9 @@
     healthcheck: /bin/true
     pull: newer
     read_only: true
+    cap_drop: [all]
+    cap_add:
+      - CAP_DAC_OVERRIDE
     secrets: >-
       {{
         [

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -39,6 +39,7 @@
     healthcheck: pg_isready -d $${POSTGRES_DB -U $${POSTGRES_USER}
     pull: newer
     read_only: true
+    cap_drop: [all]
 
 - name: Ensure the PostgreSQL container is healthy for {{ postgres_database }}
   ansible.builtin.command: podman healthcheck run {{ postgres_pod }}-postgres

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -51,6 +51,7 @@
     healthcheck: redis-cli --user ping --pass '' ping | grep PONG
     pull: newer
     read_only: true
+    cap_drop: [all]
 
 - name: Ensure the Redis container is healthy for {{ redis_pod }}
   ansible.builtin.command: podman healthcheck run {{ redis_pod }}-redis


### PR DESCRIPTION
This reduces the surface of abuse for the containers

Also fix how we log the containers logs on error, as some have no health status