### PR TITLE
Don't use ansible-compat 25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyc
 
 # Testing
+.ansible/
 .cache/
 .dwas/
 _artifacts/

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -4,3 +4,6 @@ ansible-lint
 molecule
 molecule-plugins[podman]
 tabulate
+# Unpin once molecule is compatible and allows specifying a working directory
+# to isolate ansible collections
+ansible-compat<25


### PR DESCRIPTION
It's currently writing into ~/.ansible without choice, seems like molecule is not yet updated for this

See https://github.com/ansible/molecule/pull/4362