### PR TITLE
Speedup some of the test setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,15 +135,6 @@ jobs:
       ANSIBLE_FORCE_COLOR: 1
     runs-on: ubuntu-latest
     steps:
-      - name: Freeing disk space
-        run: >-
-          echo "--> Original:"
-          && df -h
-          && sudo rm -rf /opt/hostedtoolcache/{CodeQL,go,PyPy,node,Ruby}
-          && sudo rm -rf /usr/lib/{jvm,google-cloud-sdk,llvm-*,mono,heroku}
-          && sudo rm -rf /usr/share/{swift,dotnet,miniconda}
-          && echo "--> Final state:"
-          && df -h
       - name: Increase subuids/subgids for runner
         run: echo "${USER}:100000:655360" | sudo tee /etc/subuid /etc/subgid
       - name: Reset podman

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -56,5 +56,9 @@ RUN useradd --create-home --groups sudo --shell /bin/bash podman && \
     mkdir -p /var/lib/systemd/linger && \
     touch /var/lib/systemd/linger/podman
 
+# Configure podman
+COPY image/isolated_hosts /etc/isolated_hosts
+COPY image/containers.conf /etc/containers/containers.conf
+
 VOLUME /home/podman/.local/share/containers
 VOLUME /home/podman/infrastructure

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -16,14 +16,22 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install required packages
 RUN apt-get update && \
-    apt-get install --assume-yes \
+    apt-get install --assume-yes --no-install-recommends \
+        aardvark-dns \
         bash \
         ca-certificates \
+        catatonit \
+        dbus-user-session \
         fuse-overlayfs \
+        init \
         iproute2 \
+        nftables \
+        passt \
         podman \
         python3 \
         sudo \
+        systemd \
+        uidmap \
         # And some utilities to help debug
         curl \
         jq \

--- a/molecule/default/image/containers.conf
+++ b/molecule/default/image/containers.conf
@@ -1,0 +1,2 @@
+[containers]
+base_hosts_file = "/etc/isolated_hosts"

--- a/molecule/default/image/isolated_hosts
+++ b/molecule/default/image/isolated_hosts
@@ -1,0 +1,2 @@
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -4,24 +4,6 @@
   gather_facts: false
 
   tasks:
-    - name: Create base etc/hosts configuration
-      become: true
-      ansible.builtin.copy:
-        content: |
-          127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
-          ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
-        dest: /etc/isolated_hosts
-        mode: "0o644"
-
-    - name: Configure podman
-      become: true
-      ansible.builtin.copy:
-        content: |
-          [containers]
-          base_hosts_file = "/etc/isolated_hosts"
-        dest: /etc/containers/containers.conf
-        mode: "0o644"
-
     - name: Gather info about all present pods
       containers.podman.podman_pod_info:
       register: _all_pods

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ pylint.max-branches = 13
 # Tests
 ##
 [tool.pytest.ini_options]
-addopts = "--color=yes --verbose --verbose"
+addopts = "--color=yes --verbose --verbose --dist=loadgroup --numprocesses 4"
 
 filterwarnings = [
     "error",

--- a/requirements/requirements-tests.txt
+++ b/requirements/requirements-tests.txt
@@ -1,5 +1,6 @@
 Pygments
 pytest
+pytest-xdist
 pytest-testinfra
 pyyaml
 requests


### PR DESCRIPTION
- Parallelize some testing operations, reducing the time it takes to run the pytest checks by half (20s)
- Stop cleaning up the space before we run, there's apparently enough space now (15s)
- Install less dependencies in the base test image (5s)
- Don't use ansible to apply the podman config in the test image (5s)
