### PR TITLE
Updates for molecule >25 which breaks discovery of collections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,6 @@ jobs:
         run: >-
           sudo sysctl net.ipv4.ip_unprivileged_port_start=80
           && cp molecule/default/privileged-env.yml .env.yml
-      - name: Ensure the default ansible collections directory is not written to by molecule
-        run: mkdir -p ~/.ansible/collections && chmod 0400 ~/.ansible/collections
       - name: molecule create
         run: molecule create
       - name: molecule converge

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,0 @@
-[defaults]
-collections_path = ./.cache/collections

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -40,7 +40,6 @@ provisioner:
   env:
     ANSIBLE_CALLBACKS_ENABLED: ansible.posix.profile_roles, ansible.posix.profile_tasks
     ANSIBLE_CALLBACK_RESULT_FORMAT: yaml
-    ANSIBLE_COLLECTIONS_PATH: ${MOLECULE_PROJECT_DIRECTORY}/.cache/collections
     ANSIBLE_DIFF_ALWAYS: "True"
     ANSIBLE_PIPELINING: "True"
     PROFILE_TASKS_SUMMARY_ONLY: "True"

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -36,7 +36,12 @@
           podman
           network
           rm
-          {{ _all_networks.networks | map(attribute='name') | reject('podman') | join(' ') }}
+          {{
+            _all_networks.networks
+            | map(attribute='name')
+            | reject('equalto', 'podman')
+            | join(' ')
+          }}
       changed_when: true
       when: _all_networks.networks | map(attribute='name') != ["podman"]
 

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,9 +1,6 @@
 -r requirements.txt
 -r requirements-tests.txt
 ansible-lint
-molecule
+molecule>=25
 molecule-plugins[podman]
 tabulate
-# Unpin once molecule is compatible and allows specifying a working directory
-# to isolate ansible collections
-ansible-compat<25


### PR DESCRIPTION
This simplifies the handling of collections, as with molecule >25, it will autodetect virtual environments and run in them instead