### PR TITLE
Explicitly specify which DB to healtcheck

### DIFF
--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -36,7 +36,7 @@
       POSTGRES_DB: "{{ postgres_database }}"
     secrets:
       - "{{ postgres_password_secret }},target=/run/secrets/postgres-password"
-    healthcheck: pg_isready -U ${POSTGRES_USER}
+    healthcheck: pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}
     pull: newer
     read_only: true
     cap_drop: [all]


### PR DESCRIPTION
This allows to not report a warning when the username is not the same as the database name