### PR TITLE
Have the infrastructure service wait on default.target

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/molecule/default/tests/test_monitoring.py
+++ b/molecule/default/tests/test_monitoring.py
@@ -80,6 +80,11 @@ def test_services_are_up(
             "1",
         ),
         (
+            "authentik-worker",
+            "prometheus.scrape.benschubert_infrastructure_auth_monitoring",
+            "1",
+        ),
+        (
             os.getenv(
                 "CONTAINER_NAME", "benschubert-infrastructure-test-container"
             ),

--- a/roles/auth/defaults/main.yml
+++ b/roles/auth/defaults/main.yml
@@ -5,7 +5,7 @@ ingress_https_port: 443
 auth_authentik_authentication_page_title: Welcome to {{ auth_authentik_hostname }}!
 auth_authentik_branding_title: Authentik
 # FIXME: keep this value up to date
-auth_authentik_image: ghcr.io/goauthentik/server:2025.6
+auth_authentik_image: ghcr.io/goauthentik/server:2025.8
 auth_authentik_superadmin_bootstrap_email: null
 auth_authentik_superadmin_bootstrap_password: null
 auth_authentik_superadmin_bootstrap_token: null

--- a/roles/auth/tasks/main.yml
+++ b/roles/auth/tasks/main.yml
@@ -143,7 +143,7 @@
     healthcheck: /lifecycle/ak healthcheck
     healthcheck_interval: 1m
     health_startup_interval: 10s
-    health_startup_timeout: 20min
+    health_startup_timeout: 10min
     sdnotify: healthy
     pull: newer
     volumes: >-
@@ -261,7 +261,7 @@
     healthcheck: /lifecycle/ak healthcheck
     healthcheck_interval: 1m
     health_startup_interval: 10s
-    health_startup_timeout: 10min
+    health_startup_timeout: 15min
     sdnotify: healthy
     pull: newer
     volumes:
@@ -301,7 +301,7 @@
         WantedBy=infrastructure.target
 
         [Service]
-        TimeoutSec=10min
+        TimeoutSec=15min
   register: _container
 
 - name: Ensure the Authentik worker container is started

--- a/roles/auth/tasks/main.yml
+++ b/roles/auth/tasks/main.yml
@@ -377,6 +377,8 @@
     monitoring_agent_prometheus_endpoints:
       - name: authentik
         address: auth:9300
+      - name: authentik-worker
+        address: auth-worker:9300
         alerting_rules_template: authentik-alerts.yml.j2
     monitoring_agent_postgres_instances:
       - instance: auth-postgres

--- a/roles/auth/tasks/main.yml
+++ b/roles/auth/tasks/main.yml
@@ -184,7 +184,6 @@
       }}
     read_only: true
     cap_drop: [all]
-    force_restart: "{{ _background.changed or _icon.changed }}"
     network:
       - ingress-auth.network
       - auth-postgres.network
@@ -213,7 +212,11 @@
   ansible.builtin.systemd_service:
     name: auth
     scope: user
-    state: "{{ _container.changed | ternary('restarted', 'started') }}"
+    state: >-
+      {{
+        (_background.changed or _icon.changed or _container.changed)
+        | ternary('restarted', 'started')
+      }}
     enabled: true
     daemon_reload: true
 

--- a/roles/auth/templates/authentik-alerts.yml.j2
+++ b/roles/auth/templates/authentik-alerts.yml.j2
@@ -1,8 +1,8 @@
 - alert: AuthentikSystemTaskUnhealthy
-  expr: rate(authentik_system_tasks_status{instance="{{ name }}", status!="successful", task_name!="update_latest_version"}[5m])> 0
+  expr: rate(authentik_tasks_errors_total{instance="{{ name }}"}[5m])> 0
   for: 0m
   labels:
     severity: critical
   annotations:
     summary: Auhtentik system task unhealthy (instance {{ '{{' }} $labels.instance {{ '}}' }})
-    description: Authentik has an unhealthy system task\n  TASK = {{ '{{' }} $labels.task_name {{ '}}' }}\n  LABELS = {{ '{{' }} $labels {{ '}}' }}
+    description: Authentik has an unhealthy system task\n  TASK = {{ '{{' }} $labels.actor_name {{ '}}' }}\n  LABELS = {{ '{{' }} $labels {{ '}}' }}

--- a/roles/auth/templates/flow-login.yml.j2
+++ b/roles/auth/templates/flow-login.yml.j2
@@ -7,12 +7,6 @@ entries:
 - model: authentik_blueprints.metaapplyblueprint
   attrs:
     identifiers:
-      name: Default - Password change flow
-    required: true
-
-- model: authentik_blueprints.metaapplyblueprint
-  attrs:
-    identifiers:
       name: benschubert.infrastructure - Recovery with email verification
     required: true
 

--- a/roles/auth/templates/flow-recovery.yml.j2
+++ b/roles/auth/templates/flow-recovery.yml.j2
@@ -4,39 +4,20 @@ version: 1
 metadata:
   name: benschubert.infrastructure - Recovery with email verification
 entries:
+  - model: authentik_blueprints.metaapplyblueprint
+    attrs:
+      identifiers:
+        name: Default - Password change flow
+      required: true
   - identifiers:
       slug: benschubert-infrastructure-recovery-flow
     id: flow
     model: authentik_flows.flow
     attrs:
-      name: Default recovery flow
+      name: Password recovery flow
       title: Reset your password
       designation: recovery
       authentication: require_unauthenticated
-  - identifiers:
-      name: benschubert-infrastructures-recovery-field-password
-    id: prompt-field-password
-    model: authentik_stages_prompt.prompt
-    attrs:
-      field_key: password
-      label: Password
-      type: password
-      required: true
-      placeholder: Password
-      order: 0
-      placeholder_expression: false
-  - identifiers:
-      name: benschubert-infrastructures-recovery-field-password-repeat
-    id: prompt-field-password-repeat
-    model: authentik_stages_prompt.prompt
-    attrs:
-      field_key: password_repeat
-      label: Password (repeat)
-      type: password
-      required: true
-      placeholder: Password (repeat)
-      order: 1
-      placeholder_expression: false
   - identifiers:
       name: benschubert-infrastructure-recovery-skip-if-restored
     id: benschubert-infrastructure-recovery-skip-if-restored
@@ -80,15 +61,6 @@ entries:
     id: benschubert-infrastructure-recovery-user-login
     model: authentik_stages_user_login.userloginstage
   - identifiers:
-      name: Change your password
-    id: stages-prompt-password
-    model: authentik_stages_prompt.promptstage
-    attrs:
-      fields:
-        - !KeyOf prompt-field-password
-        - !KeyOf prompt-field-password-repeat
-      validation_policies: []
-  - identifiers:
       target: !KeyOf flow
       stage: !KeyOf benschubert-infrastructure-recovery-identification
       order: 10
@@ -113,7 +85,7 @@ entries:
   - identifiers:
       pk: 1219d06e-2c06-4c5b-a162-78e3959c6cf0
       target: !KeyOf flow
-      stage: !KeyOf stages-prompt-password
+      stage: !Find [authentik_stages_prompt.promptstage, [name, default-password-change-prompt]]
       order: 30
     model: authentik_flows.flowstagebinding
     attrs:

--- a/roles/ingress/tasks/main.yml
+++ b/roles/ingress/tasks/main.yml
@@ -59,7 +59,6 @@
     name: ingress
     image: "{{ ingress_traefik_image }}"
     state: quadlet
-    force_restart: "{{ _configuration.changed }}"
     pull: newer
     network: |
       {{
@@ -119,7 +118,7 @@
   ansible.builtin.systemd_service:
     name: ingress
     scope: user
-    state: "{{ _container.changed | ternary('restarted', 'started') }}"
+    state: "{{ (_configuration.changed or _container.changed) | ternary('restarted', 'started') }}"
     enabled: true
     daemon_reload: true
 

--- a/roles/main/templates/infrastructure.target.j2
+++ b/roles/main/templates/infrastructure.target.j2
@@ -1,9 +1,8 @@
 {{ template_warning }}
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 
 [Unit]
-After=network-online.target
 Description=All services forming the infrastructure stack
 
 PropagatesStopTo=auth-postgres.service

--- a/roles/monitoring/tasks/_grafana.yml
+++ b/roles/monitoring/tasks/_grafana.yml
@@ -123,7 +123,7 @@
     healthcheck: curl --fail http://localhost:3000
     healthcheck_interval: 1m
     health_startup_interval: 10s
-    health_startup_timeout: 5min
+    health_startup_timeout: 7min
     sdnotify: healthy
     read_only: true
     cap_drop: [all]
@@ -193,7 +193,7 @@
         WantedBy=infrastructure.target
 
         [Service]
-        TimeoutSec=5min
+        TimeoutSec=7min
   register: _container
 
 - name: Ensure the Grafana container is started

--- a/roles/monitoring/tasks/_loki.yml
+++ b/roles/monitoring/tasks/_loki.yml
@@ -35,7 +35,6 @@
     health_startup_interval: 10s
     health_startup_timeout: 5min
     sdnotify: healthy
-    force_restart: "{{ _configuration.changed }}"
     read_only: true
     cap_drop: [all]
     pull: newer
@@ -67,7 +66,7 @@
   ansible.builtin.systemd_service:
     name: monitoring-loki
     scope: user
-    state: "{{ _container.changed | ternary('restarted', 'started') }}"
+    state: "{{ (_configuration.changed or _container.changed) | ternary('restarted', 'started') }}"
     enabled: true
     daemon_reload: true
 

--- a/roles/monitoring/tasks/_mimir.yml
+++ b/roles/monitoring/tasks/_mimir.yml
@@ -42,7 +42,6 @@
   containers.podman.podman_container:
     name: monitoring-mimir
     state: quadlet
-    force_restart: "{{ _configuration.changed }}"
     image: "{{ monitoring_mimir_image }}"
     command: --config.file=/etc/mimir/mimir.yml
     # FIXME: the image from 2.13 now doesn't have curl or wget
@@ -88,7 +87,7 @@
   ansible.builtin.systemd_service:
     name: monitoring-mimir
     scope: user
-    state: "{{ _container.changed | ternary('restarted', 'started') }}"
+    state: "{{ (_configuration.changed or _container.changed) | ternary('restarted', 'started') }}"
     enabled: true
     daemon_reload: true
 

--- a/roles/monitoring/tasks/agent.yml
+++ b/roles/monitoring/tasks/agent.yml
@@ -121,7 +121,6 @@
       - --disable-reporting
       - --storage.path=/var/lib/alloy/data
       - /etc/alloy/config.alloy
-    force_restart: "{{ _configuration.changed }}"
     # FIXME: Once https://github.com/grafana/alloy/issues/477 is resolved
     #        we should be able to set it to curl/wget
     # healthcheck: wget -O- http://localhost:9009/-/healthy
@@ -177,7 +176,7 @@
   ansible.builtin.systemd_service:
     name: "{{ monitoring_agent_container }}"
     scope: user
-    state: "{{ _container.changed | ternary('restarted', 'started') }}"
+    state: "{{ (_container.changed or _configuration.changed) | ternary('restarted', 'started') }}"
     enabled: true
     daemon_reload: true
 

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -27,7 +27,7 @@
       POSTGRES_DB: "{{ postgres_database }}"
     secrets:
       - "{{ postgres_password_secret }},target=/run/secrets/postgres-password"
-    healthcheck: pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}
+    healthcheck: pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}
     healthcheck_interval: 1m
     health_startup_interval: 10s
     health_startup_timeout: 5min

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -28,7 +28,6 @@
     command: [redis-server, /etc/redis.conf]
     user: redis
     state: quadlet
-    force_restart: "{{ _configuration.changed }}"
     volumes:
       - "{{ redis_data_path }}/:/data:rw,U,Z"
     healthcheck: redis-cli --user ping --pass '' ping | grep PONG
@@ -54,7 +53,7 @@
   ansible.builtin.systemd_service:
     name: "{{ redis_container }}"
     scope: user
-    state: "{{ _container.changed | ternary('restarted', 'started') }}"
+    state: "{{ (_configuration.changed or _container.changed) | ternary('restarted', 'started') }}"
     enabled: true
     daemon_reload: true
 

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -44,6 +44,10 @@
       - "{{ redis_network }}.network"
     secrets:
       - "{{ redis_container }}-config,target=/etc/redis.conf"
+    quadlet_options:
+      - |
+        [Service]
+        TimeoutSec=5min
   register: _container
 
 - name: Ensure the Redis container is running for {{ redis_container }}


### PR DESCRIPTION
This is meant to be used as a user, not as a global service and thus it can't depend on multi-user.target