### PR TITLE
Use fuse-overlayfs to speedup the setup of the containers

### DIFF
--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -60,6 +60,7 @@ RUN useradd --create-home --groups sudo --shell /bin/bash podman && \
 # Configure podman
 COPY image/isolated_hosts /etc/isolated_hosts
 COPY image/containers.conf /etc/containers/containers.conf
+COPY --chown=podman:podman image/storage.conf /home/podman/.config/containers/storage.conf
 
 VOLUME /home/podman/.local/share/containers
 VOLUME /home/podman/infrastructure

--- a/molecule/default/image/storage.conf
+++ b/molecule/default/image/storage.conf
@@ -1,0 +1,7 @@
+# FIXME: Use native overlay once it supports user namespaces
+#        See https://github.com/containers/podman/issues/16541
+[storage]
+driver = "overlay"
+
+[storage.options]
+mount_program = "/usr/bin/fuse-overlayfs"


### PR DESCRIPTION
Otherwise we would be using the native overlay which has some performance problems with rootless

See https://github.com/containers/podman/issues/16541