### PR TITLE
Stop restarting the monitoring agents when ingress restarts

### DIFF
--- a/roles/monitoring/tasks/agent.yml
+++ b/roles/monitoring/tasks/agent.yml
@@ -170,8 +170,8 @@
         [Unit]
         Before=infrastructure.target
         StopPropagatedFrom=infrastructure.target
-        Requires=auth.service
-        Requires=ingress.service
+        Wants=auth.service
+        Wants=ingress.service
 
         [Service]
         TimeoutSec=5min


### PR DESCRIPTION
This increases the time to restart by a lot