### PR TITLE
Retry the authentik healthcheck to handle postgres updates

### DIFF
--- a/extensions/molecule/default/create.yml
+++ b/extensions/molecule/default/create.yml
@@ -72,6 +72,7 @@
         dest: "{{ molecule_ephemeral_directory | dirname }}/original-debian-13.raw"
         mode: "0o644"
         checksum: sha512:https://cloud.debian.org/images/cloud/trixie/latest/SHA512SUMS
+        timeout: 300
 
     - name: Copy the pre-downloaded image
       ansible.builtin.copy:

--- a/roles/auth/tasks/main.yml
+++ b/roles/auth/tasks/main.yml
@@ -211,6 +211,10 @@
   become: true
   ansible.builtin.command: podman healthcheck run auth
   changed_when: false
+  register: _cmd
+  until: _cmd.rc == 0
+  retries: 15
+  delay: 5
 
 - name: Setup the Authentik worker container
   become: true
@@ -304,6 +308,10 @@
   become: true
   ansible.builtin.command: podman healthcheck run auth-worker
   changed_when: false
+  register: _cmd
+  until: _cmd.rc == 0
+  retries: 15
+  delay: 5
 
 - name: Setup an ingress for Authentik
   ansible.builtin.import_role:


### PR DESCRIPTION
When postgres updates, the healthchecks fails for a few seconds, but the system recover