### PR TITLE
Allow excluding some services from the 4XX alert

### DIFF
--- a/roles/ingress/defaults/main.yml
+++ b/roles/ingress/defaults/main.yml
@@ -9,3 +9,4 @@ ingress_traefik_default_certificates_resolver: null
 ingress_traefik_environment_variables: {}
 ingress_traefik_image: docker.io/traefik:latest
 ingress_traefik_secrets: {}
+ingress_traefik_4xx_alerts_exclude_services: []

--- a/roles/ingress/meta/argument_specs.yml
+++ b/roles/ingress/meta/argument_specs.yml
@@ -69,6 +69,13 @@ argument_specs:
             <key: value>"
           - The key of each secret will be set as an environment variable
             pointing to the secret containing the value
+      ingress_traefik_4xx_alerts_exclude_services:
+        type: list
+        default: []
+        elements: str
+        description:
+          - A list of services that should be excluded from the global ingress
+            4XX alerts
       template_warning:
         type: str
         required: true

--- a/roles/ingress/templates/traefik-alerts.yml.j2
+++ b/roles/ingress/templates/traefik-alerts.yml.j2
@@ -8,7 +8,10 @@
     description: Traefik returned a 5xx response \n  VALUE = {{ '{{' }} $value {{ '}}' }}\n  LABELS = {{ '{{' }} $labels {{ '}}' }}
 
 - alert: TraefikHigh4xxErrorRate
-  expr: sum(rate(traefik_service_requests_total{instance="{{ name }}", code=~"4.*"}[5m])) by (service) / sum(rate(traefik_service_requests_total[5m])) by (service) > 0.2
+  expr: |
+    sum(rate(traefik_service_requests_total{instance="{{ name }}", code=~"4.*"{% if ingress_traefik_4xx_alerts_exclude_services %},service!~"{{ "|".join(ingress_traefik_4xx_alerts_exclude_services) }}"{% endif %}}[5m])) by (service)
+    /
+    sum(rate(traefik_service_requests_total{instance="{{ name }}"{% if ingress_traefik_4xx_alerts_exclude_services %},service!~"{{ "|".join(ingress_traefik_4xx_alerts_exclude_services) }}"{% endif %}}[5m])) by (service) > 0.2
   for: 3m
   labels:
     severity: critical

--- a/roles/main/meta/argument_specs.yml
+++ b/roles/main/meta/argument_specs.yml
@@ -297,6 +297,13 @@ argument_specs:
         description:
           - Whether the TLS certificate to access the Traefik should be
             validated or not
+      ingress_traefik_4xx_alerts_exclude_services:
+        type: list
+        default: []
+        elements: str
+        description:
+          - A list of services that should be excluded from the global ingress
+            4XX alerts
 
       ##
       # Monitoring


### PR DESCRIPTION
In some cases, some services might have expected 4XX and this is just noisy