### PR TITLE
Give an explicit name to the grafana and ingress external bridge

### DIFF
--- a/roles/ingress/tasks/main.yml
+++ b/roles/ingress/tasks/main.yml
@@ -13,6 +13,9 @@
     name: ingress
     internal: false
     state: quadlet
+    quadlet_options: |
+      [Network]
+      PodmanArgs= --interface-name br-traefik
 
 - name: Ensure the parent directory for traefik exists
   become: true

--- a/roles/monitoring/tasks/_grafana.yml
+++ b/roles/monitoring/tasks/_grafana.yml
@@ -54,6 +54,10 @@
   containers.podman.podman_network:
     name: monitoring-grafana-external
     state: quadlet
+    quadlet_options: |
+      [Network]
+      PodmanArgs= --interface-name br-grafana
+
 
 - name: Create an application for Grafana on Authentik
   ansible.builtin.import_role:


### PR DESCRIPTION
This allows setting specific firewall rules based on the network for networks that are allowing external access.