### PR TITLE
Set the mimir server timeout to 6m to avoid Prometheus alerts

### DIFF
--- a/extensions/molecule/default/create.yml
+++ b/extensions/molecule/default/create.yml
@@ -68,18 +68,20 @@
 
     - name: Download the Debian base image
       ansible.builtin.get_url:
-        url: https://cloud.debian.org/images/cloud/trixie/latest/debian-13-genericcloud-amd64.raw
-        dest: "{{ molecule_ephemeral_directory | dirname }}/original-debian-13.raw"
+        url: http://cloud.debian.org/images/cloud/trixie/latest/debian-13-genericcloud-amd64.tar.xz
+        dest: "{{ molecule_ephemeral_directory | dirname }}/debian-13-genericcloud-amd64.tar.xz"
         mode: "0o644"
         checksum: sha512:https://cloud.debian.org/images/cloud/trixie/latest/SHA512SUMS
-        timeout: 300
+        timeout: 180
 
-    - name: Copy the pre-downloaded image
-      ansible.builtin.copy:
-        src: "{{ molecule_ephemeral_directory | dirname }}/original-debian-13.raw"
-        dest: "{{ pool_path }}/molecule-benschubert-infrastructure-test-disk.raw"
-        mode: "0o644"
-        force: false
+    - name: Extract the pre-downloaded image
+      ansible.builtin.command:
+        cmd: tar -xJf {{ molecule_ephemeral_directory | dirname }}/debian-13-genericcloud-amd64.tar.xz --transform 's|^disk\.raw$|molecule-benschubert-infrastructure-test-disk.raw|' disk.raw
+        creates: "{{ pool_path }}/molecule-benschubert-infrastructure-test-disk.raw"
+        chdir: "{{ pool_path }}"
+      register: _out
+      tags:
+        - skip_ansible_lint
 
     - name: Expand the disk
       ansible.builtin.command:

--- a/roles/monitoring/tasks/_mimir.yml
+++ b/roles/monitoring/tasks/_mimir.yml
@@ -93,18 +93,35 @@
         WantedBy=infrastructure.target
   register: _container
 
-- name: Ensure the Mimir container is started
-  become: true
-  ansible.builtin.systemd_service:
-    name: monitoring-mimir
-    state: "{{ (_configuration.changed or _container.changed) | ternary('restarted', 'started') }}"
-    enabled: true
-    daemon_reload: true
+- name: Start and check the health of the Mimir container
+  block:
+    - name: Ensure the Mimir container is started
+      become: true
+      ansible.builtin.systemd_service:
+        name: monitoring-mimir
+        state: >-
+          {{ (_configuration.changed or _container.changed) | ternary('restarted', 'started') }}
+        enabled: true
+        daemon_reload: true
 
-- name: Ensure the Mimir container is healthy
-  become: true
-  ansible.builtin.command: podman healthcheck run monitoring-mimir
-  changed_when: false
+    - name: Ensure the Mimir container is healthy
+      become: true
+      ansible.builtin.command: podman healthcheck run monitoring-mimir
+      changed_when: false
+  rescue:
+    - name: Gather the logs of the Mimir service
+      become: true
+      ansible.builtin.command:
+        cmd: journalctl -u monitoring-mimir.service --no-pager -n 20
+      changed_when: false
+      register: _mimir_logs
+
+    - name: And finally fail
+      ansible.builtin.fail:
+        msg: |-
+          Mimir is unhealthy:
+
+          {{ _mimir_logs.stdout }}
 
 - name: Create an application for Mimir on Authentik
   ansible.builtin.import_role:

--- a/roles/monitoring/templates/mimir.yml.j2
+++ b/roles/monitoring/templates/mimir.yml.j2
@@ -59,6 +59,8 @@ ruler_storage:
 server:
   http_listen_port: 9009
   log_level: {{ monitoring_mimir_log_level }}
+  # See https://github.com/grafana/mimir/issues/4724
+  http_server_idle_timeout: 6m
 
 store_gateway:
   sharding_ring:


### PR DESCRIPTION
Otherwise the prometheus client fails to detect a timeout when contacting alertmanager and triggers an alarm